### PR TITLE
Update MAKO documentation and release publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,6 @@ ENABLE_MAKO=1 %command%
 
 See [Building from Source](engine/docs/BUILDING-FROM-SOURCE.md), [Configuration](engine/docs/CONFIGURATION.md), and [Troubleshooting](engine/docs/TROUBLESHOOTING.md) for the complete standalone workflow.
 
-## License
-
-MAKO is distributed under [GPL-3.0-or-later](LICENSE.md). The root license also preserves the BSD-3-Clause and MIT notices required by incorporated upstream code.
-
 ## Featured in
 
 Community creators have covered and tested the project on Steam Deck hardware. See [Featured In](plugin/docs/FEATURED_IN.md) for video links, channels, and coverage details.
@@ -157,3 +153,7 @@ MAKO is built on the work of two open-source projects and their communities:
 MAKO also thanks the **Lossless Scaling developers** for the frame-generation and scaling technology accessed through each user's licensed installation, and the **Decky Loader team**, community contributors, testers, guide authors, and creators who helped make the project possible.
 
 The original copyright and license notices are preserved in [LICENSE.md](LICENSE.md). MAKO is an independent community project and is not affiliated with or endorsed by Lossless Scaling, Decky Loader, or either upstream project.
+
+## License
+
+MAKO is distributed under [GPL-3.0-or-later](LICENSE.md). The root license also preserves the BSD-3-Clause and MIT notices required by incorporated upstream code.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 > [!IMPORTANT]
-> **Decky LSFG-VK Experimental is now MAKO.** This repository is the new home and continuation of [Decky LSFG-VK Experimental](https://github.com/eugeniosegala/decky-lsfg-vk-experimental). Future development, releases, documentation, and issue tracking happen here.
+> **Decky LSFG-VK Experimental and LSFG-VK Experimental are now MAKO.** This repository is the new home and continuation of [Decky LSFG-VK Experimental](https://github.com/eugeniosegala/decky-lsfg-vk-experimental) and [LSFG-VK Experimental](https://github.com/eugeniosegala/lsfg-vk-experimental). Future development, releases, documentation, and issue tracking happen here.
 
 > **Independent project and Lossless Scaling requirement:** MAKO is an independent Linux graphics project comprising MAKO Decky and MAKO Renderer. It brings Lossless Scaling frame generation to Steam Deck and desktop Linux today, with scaling support planned as the project expands. MAKO requires the `Lossless.dll` supplied by a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation but does not bundle, copy, or modify that proprietary library. Test it per game; MAKO is not an official Lossless Scaling, Decky Loader, or lsfg-vk release.
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 | Component | Recommended for | Releases |
 |-----------|-----------------|----------|
-| **MAKO Decky** | Steam Deck and Decky Loader users | **[Download the latest Decky ZIP](https://github.com/eugeniosegala/MAKO/releases/latest)** · [All MAKO Decky releases](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Aplugin-v) |
-| **MAKO Renderer** | Direct Vulkan-layer installation without Decky | **[Browse MAKO Renderer releases](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Arender-v)** |
+| **MAKO Decky** | Steam Deck and Decky Loader users | MAKO-branded ZIPs are not published yet · [Legacy experimental releases](https://github.com/eugeniosegala/decky-lsfg-vk-experimental/releases) |
+| **MAKO Renderer** | Direct Vulkan-layer installation without Decky | MAKO-branded archives are not published yet · [Legacy renderer releases](https://github.com/eugeniosegala/lsfg-vk-experimental/releases) |
 
-MAKO Decky releases use `plugin-v…` tags and own the repository's **Latest** release. Standalone MAKO Renderer releases use `render-v…` tags and remain on their filtered release track.
+The first MAKO-branded Decky ZIP and Renderer archive have not been released yet. The legacy release tracks above remain available for the previous experimental projects, but their packages, wrapper names, and instructions still use the old LSFG-VK identities. This README describes MAKO and will link to its own release tracks once the first MAKO packages are published.
 
 ## ✨ Highlights
 
@@ -51,7 +51,7 @@ Every game, renderer, and display setup behaves differently. Compare Fixed and A
 
 1. **Install Decky Loader** if needed. Switch to Desktop Mode and follow the [official Decky Loader installation guide](https://github.com/SteamDeckHomebrew/decky-loader#-installation), then return to Game Mode.
 2. **Install [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) from Steam.** MAKO needs the licensed installation's `Lossless.dll`.
-3. **Download the latest MAKO Decky ZIP** from the [latest Decky release](https://github.com/eugeniosegala/MAKO/releases/latest).
+3. **Wait for the first MAKO Decky ZIP.** MAKO-branded packages are not published yet; see the release-status note above before installing a legacy experimental package.
 4. In Decky's settings, enable **Developer Mode**, then select **Developer > Install Plugin from Zip**.
 5. Open **Mako** and select **Install MAKO Renderer (developer build)**. This required step installs the renderer bundled in the ZIP into MAKO's private location.
 6. Leave the defaults in place unless a game needs adjustment. Fixed 2x is the normal starting point; Adaptive Frame Generation is optional.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ The wrapper applies only to the selected Heroic games and enables the private MA
 > [!IMPORTANT]
 > After installing a newer MAKO ZIP, return to **Flatpak Setup** and select **Update** for Heroic's matching runtime extension. This replaces Heroic's Flatpak engine with the version bundled in the new ZIP while preserving its preparation and per-game Wrapper commands.
 
+### EmuDeck and Dolphin
+
+EmuDeck's Dolphin is a Flatpak application, so it uses the same **Flatpak Setup** screen but does not need Heroic's per-game Wrapper field:
+
+1. In Mako, select **Flatpak Setup** and prepare **Dolphin Emulator**. Install the matching runtime extension when prompted; current EmuDeck Dolphin builds commonly use **25.08** through the KDE runtime.
+2. In Dolphin, set **Graphics > General > Backend** to **Vulkan**.
+3. Launch your game normally from EmuDeck or its Steam shortcut. Do **not** add `~/.local/bin/mako-run`, `%command%`, or a Wrapper field for Dolphin.
+
+Preparing Dolphin grants it access to MAKO's configuration and `Lossless.dll`, then enables the private Vulkan layer only inside Dolphin's Flatpak sandbox. The setting applies to Dolphin launches generally; use MAKO profiles if you need different renderer settings for different games.
+
+> [!IMPORTANT]
+> After updating MAKO, return to **Flatpak Setup** and select **Update** for Dolphin's matching runtime extension as well.
+
 ### Updating MAKO Decky
 
 The clean update path avoids Decky retaining an older backend or bundled payload:

--- a/README.md
+++ b/README.md
@@ -13,10 +13,13 @@
 
 | Component | Recommended for | Releases |
 |-----------|-----------------|----------|
-| **MAKO Decky** | Steam Deck and Decky Loader users | MAKO-branded ZIPs are not published yet · [Legacy experimental releases](https://github.com/eugeniosegala/decky-lsfg-vk-experimental/releases) |
-| **MAKO Renderer** | Direct Vulkan-layer installation without Decky | MAKO-branded archives are not published yet · [Legacy renderer releases](https://github.com/eugeniosegala/lsfg-vk-experimental/releases) |
+| **MAKO Decky** | Steam Deck and Decky Loader users | [Download the latest Decky ZIP](https://github.com/eugeniosegala/MAKO/releases/latest) · [All MAKO Decky releases](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Aplugin-v) |
+| **MAKO Renderer** | Direct Vulkan-layer installation without Decky | [Browse MAKO Renderer releases](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Arender-v) |
 
-The first MAKO-branded Decky ZIP and Renderer archive have not been released yet. The legacy release tracks above remain available for the previous experimental projects, but their packages, wrapper names, and instructions still use the old LSFG-VK identities. This README describes MAKO and will link to its own release tracks once the first MAKO packages are published.
+MAKO Decky releases are normal GitHub releases and the current one is marked
+**Latest**. MAKO Renderer builds are separate prereleases. Legacy experimental
+packages remain available under their old project names, but their wrapper
+names and instructions do not describe MAKO.
 
 ## ✨ Highlights
 
@@ -51,7 +54,7 @@ Every game, renderer, and display setup behaves differently. Compare Fixed and A
 
 1. **Install Decky Loader** if needed. Switch to Desktop Mode and follow the [official Decky Loader installation guide](https://github.com/SteamDeckHomebrew/decky-loader#-installation), then return to Game Mode.
 2. **Install [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) from Steam.** MAKO needs the licensed installation's `Lossless.dll`.
-3. **Wait for the first MAKO Decky ZIP.** MAKO-branded packages are not published yet; see the release-status note above before installing a legacy experimental package.
+3. **Download the latest MAKO Decky ZIP** from the release link above.
 4. In Decky's settings, enable **Developer Mode**, then select **Developer > Install Plugin from Zip**.
 5. Open **Mako** and select **Install MAKO Renderer (developer build)**. This required step installs the renderer bundled in the ZIP into MAKO's private location.
 6. Leave the defaults in place unless a game needs adjustment. Fixed 2x is the normal starting point; Adaptive Frame Generation is optional.

--- a/README.md
+++ b/README.md
@@ -126,7 +126,10 @@ Profiles and Steam launch options are retained. The private native engine and la
 Decky is optional. Linux users can build and install MAKO Renderer directly as an implicit Vulkan layer:
 
 ```bash
-cmake -S engine -B engine/build -DCMAKE_BUILD_TYPE=Release
+cmake -S engine -B engine/build \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DMAKO_BUILD_UI=On \
+  -DMAKO_INSTALL_XDG_FILES=On
 cmake --build engine/build
 sudo cmake --install engine/build
 ```

--- a/README.md
+++ b/README.md
@@ -121,10 +121,6 @@ Profiles and Steam launch options are retained. The private native engine and la
 - [Local packaging and publishing](plugin/docs/PACKAGING.md): build a ZIP for a Steam machine or publish a release.
 - [MAKO Renderer documentation](engine/README.md): engine identity, source builds, configuration, and direct use.
 
-## Featured in
-
-Community creators have covered and tested the project on Steam Deck hardware. See [Featured In](plugin/docs/FEATURED_IN.md) for video links, channels, and coverage details.
-
 ## Use MAKO Renderer directly
 
 Decky is optional. Linux users can build and install MAKO Renderer directly as an implicit Vulkan layer:
@@ -146,6 +142,10 @@ See [Building from Source](engine/docs/BUILDING-FROM-SOURCE.md), [Configuration]
 ## License
 
 MAKO is distributed under [GPL-3.0-or-later](LICENSE.md). The root license also preserves the BSD-3-Clause and MIT notices required by incorporated upstream code.
+
+## Featured in
+
+Community creators have covered and tested the project on Steam Deck hardware. See [Featured In](plugin/docs/FEATURED_IN.md) for video links, channels, and coverage details.
 
 ## Credits and project lineage
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 > [!IMPORTANT]
 > **Decky LSFG-VK Experimental and LSFG-VK Experimental are now MAKO.** This repository is the new home and continuation of [Decky LSFG-VK Experimental](https://github.com/eugeniosegala/decky-lsfg-vk-experimental) and [LSFG-VK Experimental](https://github.com/eugeniosegala/lsfg-vk-experimental). Future development, releases, documentation, and issue tracking happen here.
 
-> **Independent project and Lossless Scaling requirement:** MAKO is an independent Linux graphics project comprising MAKO Decky and MAKO Renderer. It brings Lossless Scaling frame generation to Steam Deck and desktop Linux today, with scaling support planned as the project expands. MAKO requires the `Lossless.dll` supplied by a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation but does not bundle, copy, or modify that proprietary library. Test it per game; MAKO is not an official Lossless Scaling, Decky Loader, or lsfg-vk release.
+> **Independent project and Lossless Scaling requirement:** MAKO is an independent Steam Deck and Steam Machine project comprising MAKO Decky and MAKO Renderer. It brings Lossless Scaling frame generation to SteamOS today, with scaling support planned as the project expands. MAKO requires the `Lossless.dll` supplied by a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation but does not bundle, copy, or modify that proprietary library. Test it per game; MAKO is not an official Lossless Scaling, Decky Loader, or lsfg-vk release.
 
 ## Downloads
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ The clean update path avoids Decky retaining an older backend or bundled payload
 4. Open Mako and select **Install MAKO Renderer (developer build)** to install the native renderer bundled in the ZIP.
 5. If you use Heroic, open **Flatpak Setup** and select **Update** for Heroic's matching runtime extension, usually **25.08**.
 
+> [!IMPORTANT]
+> **Preferred clean update:** To prevent Decky retaining a previous plugin backend or bundled payload, especially when moving between local test ZIPs, uninstall **Mako** from Decky, install the newer ZIP, restart your Steam Deck or Steam Machine, then select **Install MAKO Renderer (developer build)** in the plugin.
+
 Profiles and Steam launch options are retained. The private native engine and launcher are recreated in step 4; shared Flatpak extensions are retained and then refreshed in step 5.
 
 ## Documentation

--- a/engine/README.md
+++ b/engine/README.md
@@ -4,6 +4,9 @@
   <img src="assets/mako-render-logo.png" width="256" alt="MAKO Renderer logo" />
 </p>
 
+> [!NOTE]
+> **LSFG-VK Experimental is now MAKO Renderer.** The [MAKO repository](https://github.com/eugeniosegala/MAKO) is its new home and continuation, including future development, releases, documentation, and issue tracking.
+
 MAKO Renderer is the Vulkan renderer and layer component of MAKO. It brings Lossless Scaling frame generation—and, as the project expands, scaling—to Steam Deck and desktop Linux.
 
 The layer is derived from [lsfg-vk](https://github.com/PancakeTAS/lsfg-vk) and retains its open-source attribution and license obligations. It requires a user-supplied `Lossless.dll` from a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation. MAKO Renderer does not bundle or replace that proprietary library.

--- a/engine/README.md
+++ b/engine/README.md
@@ -11,9 +11,12 @@ MAKO Renderer is the Vulkan renderer and layer component of MAKO. It brings Loss
 
 The layer is derived from [lsfg-vk](https://github.com/PancakeTAS/lsfg-vk) and retains its open-source attribution and license obligations. It requires a user-supplied `Lossless.dll` from a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation. MAKO Renderer does not bundle or replace that proprietary library.
 
-## Release status
+## Downloads
 
-MAKO-branded Renderer archives are not published yet. The previous [LSFG-VK Experimental releases](https://github.com/eugeniosegala/lsfg-vk-experimental/releases) remain available, but their archives, wrapper names, and instructions use the old project identity. Build MAKO Renderer from this repository for the current standalone workflow; this page will link to MAKO archives once they are released.
+Standalone Linux and Flatpak archives are published on the
+[MAKO Renderer release track](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Arender-v).
+Steam Deck users who want the managed workflow should install the
+[latest MAKO Decky release](https://github.com/eugeniosegala/MAKO/releases/latest).
 
 ## Install
 
@@ -25,11 +28,12 @@ For SteamOS, the companion **MAKO Decky** plugin is the recommended installation
 ~/.local/bin/mako-run %command%
 ```
 
-See the [main MAKO installation guide](../README.md#install-and-use) for the complete Decky, Heroic, EmuDeck, and Dolphin setup. The first MAKO-branded Decky ZIP has not been published yet; do not mistake an empty MAKO release page for an installer.
+See the [main MAKO installation guide](../README.md#install-and-use) for the complete Decky, Heroic, EmuDeck, and Dolphin setup.
 
 ### Desktop Linux: install a Renderer archive
 
-Once MAKO Renderer archives are published, download the Linux archive and extract it into your user-local prefix:
+Download the Linux archive from the Renderer release and extract it into your
+user-local prefix:
 
 ```bash
 mkdir -p ~/.local

--- a/engine/README.md
+++ b/engine/README.md
@@ -11,9 +11,108 @@ MAKO Renderer is the Vulkan renderer and layer component of MAKO. It brings Loss
 
 The layer is derived from [lsfg-vk](https://github.com/PancakeTAS/lsfg-vk) and retains its open-source attribution and license obligations. It requires a user-supplied `Lossless.dll` from a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation. MAKO Renderer does not bundle or replace that proprietary library.
 
-## Download
+## Release status
 
-Standalone Linux and Flatpak archives are published on the [`render-v…` MAKO Renderer release track](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Arender-v). Steam Deck users who want the managed Decky experience should install the [latest MAKO Decky release](https://github.com/eugeniosegala/MAKO/releases/latest) instead.
+MAKO-branded Renderer archives are not published yet. The previous [LSFG-VK Experimental releases](https://github.com/eugeniosegala/lsfg-vk-experimental/releases) remain available, but their archives, wrapper names, and instructions use the old project identity. Build MAKO Renderer from this repository for the current standalone workflow; this page will link to MAKO archives once they are released.
+
+## Install
+
+### Steam Deck or Steam Machine: use MAKO Decky
+
+For SteamOS, the companion **MAKO Decky** plugin is the recommended installation path. It installs the renderer in a private location, creates the `mako-run` launcher, and prepares supported Flatpak applications. Install the Decky ZIP, open **Mako**, and select **Install MAKO Renderer (developer build)**. For a native Steam or Proton game, set its Steam launch option to:
+
+```text
+~/.local/bin/mako-run %command%
+```
+
+See the [main MAKO installation guide](../README.md#install-and-use) for the complete Decky, Heroic, EmuDeck, and Dolphin setup. The first MAKO-branded Decky ZIP has not been published yet; do not mistake an empty MAKO release page for an installer.
+
+### Desktop Linux: install a Renderer archive
+
+Once MAKO Renderer archives are published, download the Linux archive and extract it into your user-local prefix:
+
+```bash
+mkdir -p ~/.local
+tar -xJf mako-render-<version>-linux.tar.xz -C ~/.local
+```
+
+The archive installs the `mako-ui` configuration application, `mako-cli`, Vulkan manifests, and the 64-bit layer. Release archives also include the matching 32-bit layer for 32-bit games. If `~/.local/bin` is not on your `PATH`, run the tools with their full paths, for example `~/.local/bin/mako-ui`.
+
+Install a licensed copy of [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) through Steam before launching a game. MAKO normally finds `Lossless.dll` in common Steam locations; choose its location explicitly in the UI or configuration file if your Steam library is elsewhere.
+
+### Build and install from source
+
+For the current standalone MAKO workflow, build the Renderer from this repository. Install the prerequisites for your distribution first, then run:
+
+```bash
+git clone https://github.com/eugeniosegala/MAKO.git
+cd MAKO/engine
+
+cmake -S . -B build -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=/usr/local \
+  -DCMAKE_CXX_COMPILER=clang++ \
+  -DMAKO_BUILD_UI=On \
+  -DMAKO_INSTALL_XDG_FILES=On
+cmake --build build
+sudo cmake --install build
+```
+
+This installs a native layer for the architecture being built. The full [building-from-source guide](docs/BUILDING-FROM-SOURCE.md) covers distribution packages, SteamOS prerequisites, 32-bit builds, and non-system installation prefixes.
+
+### Flatpak applications
+
+For a Flatpak game or emulator, install the matching MAKO Vulkan runtime extension and grant that application access to MAKO's configuration and the Steam library. MAKO Decky performs this setup through **Flatpak Setup**; direct installs can follow the [Flatpak guide](docs/FLATPAK-GUIDE.md).
+
+## Configure and use
+
+1. Start `mako-ui` (or `~/.local/bin/mako-ui` from an extracted archive), choose the Lossless Scaling DLL if MAKO did not find it automatically, and add a profile for the game.
+2. Set the profile's **Active In** entry to the game's Linux binary or Windows executable name. Start with fixed **2x** frame generation and adjust from there.
+3. Launch only the game through MAKO. For a Steam game, use this launch option:
+
+   ```text
+   ENABLE_MAKO=1 %command%
+   ```
+
+   For a direct desktop command, prefix the game's command in the same way:
+
+   ```bash
+   ENABLE_MAKO=1 your-game-command
+   ```
+
+4. Start the game normally. MAKO's implicit Vulkan layer remains off for every other process.
+
+You can configure MAKO without the UI by editing `~/.config/mako-render/conf.toml`. This minimal profile selects a Windows game executable and enables 2x frame generation:
+
+```toml
+[[profile]]
+name = "My game"
+active_in = ["Game.exe"]
+multiplier = 2
+frame_generation_enabled = true
+```
+
+Use the game's own frame limiter and test V-Sync both on and off; the smoother result is game- and compositor-dependent. See [Configuration](docs/CONFIGURATION.md) for every setting, profile matching, adaptive frame generation, and environment-variable overrides.
+
+### Validate the configuration
+
+After installing the command-line tool, validate the default configuration with:
+
+```bash
+mako-cli validate
+```
+
+Use an explicit file when needed:
+
+```bash
+mako-cli validate --config ~/.config/mako-render/conf.toml
+```
+
+For a layer-activation check on a Vulkan-capable system with `vulkaninfo` installed:
+
+```bash
+ENABLE_MAKO=1 vulkaninfo | grep -i VK_LAYER_MAKO_render
+```
 
 ## Identity
 
@@ -26,7 +125,7 @@ Standalone Linux and Flatpak archives are published on the [`render-v…` MAKO R
 - Activation: `ENABLE_MAKO=1`
 - Deactivation: `DISABLE_MAKO=1`
 
-## Build
+## Build packages
 
 MAKO Renderer uses CMake and requires Vulkan development headers. The optional desktop interface also requires Qt 6.
 
@@ -45,14 +144,9 @@ Local Linux archives and Flatpak runtime extensions can be built with:
 
 Artifacts are written under `engine/out/`. The Decky package in the sibling `plugin/` directory builds and bundles this engine automatically through `pnpm run package:local-engine`.
 
-## Direct activation
+## More documentation
 
-For development outside Decky, activate only the MAKO layer for the launched process:
-
-```bash
-ENABLE_MAKO=1 your-game-command
-```
-
-Most Steam Deck users should use MAKO Decky and its `~/.local/bin/mako-run` wrapper instead of managing layer paths manually.
-
-See [Configuration](docs/CONFIGURATION.md), [Building from Source](docs/BUILDING-FROM-SOURCE.md), and [Troubleshooting](docs/TROUBLESHOOTING.md) for detailed workflows.
+- [Configuration](docs/CONFIGURATION.md): profiles, frame-generation controls, Adaptive mode, and environment variables.
+- [Flatpak guide](docs/FLATPAK-GUIDE.md): runtime extensions and direct Flatpak application overrides.
+- [Building from Source](docs/BUILDING-FROM-SOURCE.md): prerequisites, SteamOS builds, and packaging.
+- [Troubleshooting](docs/TROUBLESHOOTING.md): activation, configuration, and presentation diagnostics.

--- a/engine/docs/ADAPTIVE-VALIDATION.md
+++ b/engine/docs/ADAPTIVE-VALIDATION.md
@@ -32,11 +32,17 @@ The suite currently locks down:
 - timestamp ordering, capacity bounds, and deterministic trace replay.
 
 `adaptive-scheduler-matrix` also runs 120 combinations of base cadence, target,
-multiplier ceiling, and Smooth Cadence. It checks output bounds and emits CSV
-when run directly:
+multiplier ceiling, and Smooth Cadence. It checks output bounds and can emit
+CSV when built in a persistent directory and run directly:
 
 ```bash
-build/mako-render/mako-adaptive-matrix > adaptive-policy-matrix.csv
+cmake -S . -B build/adaptive-policy \
+  -DMAKO_BUILD_VK_LAYER=OFF \
+  -DMAKO_BUILD_UI=OFF \
+  -DMAKO_BUILD_CLI=OFF \
+  -DBUILD_TESTING=ON
+cmake --build build/adaptive-policy --target mako-adaptive-matrix
+build/adaptive-policy/mako-render/mako-adaptive-matrix > adaptive-policy-matrix.csv
 ```
 
 The CSV includes average generated frames, generated-frame share, and frame-count

--- a/engine/docs/BUILDING-FROM-SOURCE.md
+++ b/engine/docs/BUILDING-FROM-SOURCE.md
@@ -118,8 +118,7 @@ git clone https://github.com/eugeniosegala/MAKO.git
 cd MAKO/engine
 ```
 
-After the first MAKO Renderer release, you can optionally check out a specific
-release tag:
+Optionally, you can check out a specific Renderer release tag:
 ```bash
 git checkout tags/render-vX.Y.Z
 ```

--- a/engine/docs/BUILDING-FROM-SOURCE.md
+++ b/engine/docs/BUILDING-FROM-SOURCE.md
@@ -118,7 +118,8 @@ git clone https://github.com/eugeniosegala/MAKO.git
 cd MAKO/engine
 ```
 
-Optionally, you can checkout a specific release tag:
+After the first MAKO Renderer release, you can optionally check out a specific
+release tag:
 ```bash
 git checkout tags/render-vX.Y.Z
 ```

--- a/engine/docs/CONFIGURATION.md
+++ b/engine/docs/CONFIGURATION.md
@@ -1,118 +1,95 @@
-# Configuration Options
+# Configuration
 
-Configuring MAKO Renderer is done either through **mako-ui** (graphical interface) or by manually editing the configuration file located at `~/.config/mako-render/conf.toml`.
+Configure MAKO Renderer with `mako-ui` or by editing
+`~/.config/mako-render/conf.toml`. The UI writes the same TOML file. MAKO
+creates profiles so different games can use different settings.
 
-Regardless of the method you choose, the concept of profiles remains the same.
-- **Profiles**: Profiles allow you to create different sets of configurations for different applications or use cases. A profile can automatically be selected through the "active_in" property.
-- **Profile Settings**: Settings related to a profile are stored under the "Profile Settings" or `[[profile]]` section.
-- **Global Settings**: Any settings in the "Global Settings" or `[global]` section apply to all profiles.
+## Profiles
 
-### All Configuration Options
+Each `[[profile]]` section is a game profile. `active_in` can match a Linux
+binary name, Windows executable, process name, or the end of an executable
+path. Use `MAKO_PROFILE` when you need to select a profile explicitly instead
+of matching it automatically.
 
-Below is a list of all available **global** configuration options:
-- **Path to Lossless Scaling / `dll`**: By default, MAKO Renderer will search certain directories for Lossless Scaling. If you have Lossless Scaling installed in a custom location, you can specify the full path to the "Lossless.dll" file inside of Lossless Scaling here.
-- **Allow half-precision / `allow_fp16`**: If enabled, this will allow MAKO Renderer to take advantage of half-precision shader operations if supported by the GPU. This has a giant performance uplift on AMD GPUs, but does not affect NVIDIA GPUs (GTX 1000-series or older cards will actually see a big performance **decrease**). This option **does not** influence quality. (Default: `true`)
+```toml
+[[profile]]
+name = "My game"
+active_in = ["Game.exe"]
+multiplier = 2
+frame_generation_enabled = true
+```
 
-Next is a list of all available **profile** configuration options:
-- **Profile Name / `name`**: The name of the profile, displayed in **mako-ui**. Additionally, this is used when selecting a profile through the `MAKO_PROFILE` environment variable.
-- **Active In / `active_in`**: A list of 1) linux binary names, such as `mpv`, 2) windows executables, such as `GenshinImpact.exe` and 3) process names, such as `GameThread`. It is also possible to specify the last part of a path (e.g. `Ghostrunner2/Binaries/Win64/Ghostrunner2-Win64-Shipping.exe`). When a process matching one of these rules is detected, this profile will be activated.
-- **Multiplier / `multiplier`**: The frame generation multiplier. A value of 3 means that for every frame rendered by the application, MAKO Renderer will generate 2 additional frames. (Default: `2`)
-- **Frame Generation / `frame_generation_enabled`**: Live synthesis switch. Set this to `false` to present the game's
-  real frames directly without model scheduling or per-swapchain interpolation resources. The Vulkan layer and shared
-  backend remain loaded so the selected Fixed or Adaptive mode can resume when this returns to `true`. (Default:
-  `true`)
-- **Adaptive Frame Generation / `adaptive`**: Experimental opt-in mode that varies between zero and three generated
-  frames per real frame to approach `target_fps` as an average. Fixed `multiplier` is ignored while this is enabled.
-  This independent Vulkan-layer scheduler does not include Lossless Scaling's Windows Queue Target modes. It cannot
-  reduce a game already rendering above the target and cannot exceed the configured maximum multiplier or 4x the
-  base framerate. (Default: `false`)
-- **Adaptive Target / `target_fps`**: Desired displayed framerate for Adaptive mode. Cap the game separately if its
-  real framerate can exceed this value. Targets above the configured multiplier limit cannot be reached. (Default: `120`)
-- **Maximum Adaptive Multiplier / `adaptive_max_multiplier`**: Limits Adaptive mode to 2x, 3x, or 4x total output.
-  Every real frame is still presented. If the target would require a higher ratio, output remains below the target
-  instead of adding the more artifact-prone generated frames. Adaptive also ramps toward this limit after startup or
-  recovery and can temporarily reduce it when added generation load harms real-frame throughput. If the compositor's
-  cadence divisor makes the first step misleading, it can make one bounded bridge test at the next step. Rejected
-  first-step probes wait 15 seconds; interrupted probes can rearm after two seconds of stable cadence. Repeated
-  failures at a higher multiplier back off progressively from 5 to 15, 30, and then 60 seconds, unless the measured
-  base rate improves by at least 15%. After a generated-image recovery, Adaptive preserves the last validated level
-  through the safety warm-up and waits five seconds before probing a higher level. Multiplier policy is frozen while
-  generated output is bypassed, so recovery cannot falsely accept a level that was not actually running. When Smooth
-  Cadence is enabled, a modest fractional target such as 60 -> 90 can validate a constant cadence to avoid alternating
-  real-only and generated frames; it returns to strict target scheduling if the higher constant workload is not
-  sustainable. An abrupt menu, focus, or display transition preserves the previous real-rate baseline and proven
-  generation level. Adaptive restores that level only after one second at least 90% of the earlier base rate; after
-  five seconds without recovery it discards the stale baseline and ramps cleanly from zero. After restoration, the
-  recovered real-only rate remains the delayed-load baseline; if the restored level then collapses throughput,
-  Adaptive measures one second without generated work and returns to the lower proven level. A validated level that
-  reaches at least 95% of the target is treated as sufficient, and a remaining deficit must persist for one second
-  before a higher multiplier is tested. (Default: `3`)
-- **Smooth Cadence / `adaptive_stable_cadence`**: When enabled, Adaptive may use the validated constant-cadence policy
-  described above instead of alternating generated-frame counts to match a fractional target exactly. Strict scheduling
-  settles first, and constant cadence is considered only when it already needs at least 95% of the corresponding integer
-  output count. A severe sustained collapse starts one second of real-only measurement; Adaptive then resumes fractional
-  scheduling or tests one higher level when the configured maximum permits it. Rescue has a 15-second cooldown and never
-  exceeds the selected maximum. Constant cadence can lower the real-frame presentation rate and feel less responsive,
-  even when displayed motion is smoother. Leave Smooth Cadence disabled to use strict target scheduling while retaining
-  the remaining Adaptive recovery, load shedding, multiplier limits, and retry backoff. (Default: `false`)
-- **Flow Scale / `flow_scale`**: The resolution scale at which the motion vectors are calculated. A lower value means better performance, but worse quality. (Default: `1.0`)
-- **Performance Mode / `performance_mode`**: When enabled, a significantly lighter frame generation model is used. This has a minor quality impact, but greatly improves performance.
-(Default: `false`)
-- **Pacing Mode / `pacing`**: This option is explained in greater detail below. Supported values are **None / `none`**.
-- **GPU / `gpu`**: The GPU to use for frame generation. This MUST be the **same GPU** as the one being used by the application. **Dual GPU is NOT supported**. You can identify a GPU through its name (e.g. `NVIDIA GeForce RTX 3080`), uppercase-only ID (e.g. `0x10DE:0x2C02`) or PCI bus ID (e.g. `3:0.0`). If not specified, the primary GPU will be used, which may lead to issues.
+## Global settings
 
-"Frame Generation", Fixed/Adaptive mode, "Multiplier", "Adaptive Target", "Maximum Adaptive Multiplier", and "Smooth Cadence" can be **hot-reloaded** when the active context has the required reserved capacity. Fixed and Adaptive share one private output set, so these ordinary controls do not invalidate or recreate the game-owned swapchain. Flow Scale, Performance Mode, GPU selection, a capacity increase beyond the reserved set, and an HDR encoding change remain pending until the game naturally recreates its swapchain; restart the game when an immediate deterministic change is required. The layer never returns an out-of-date result merely because a Decky setting changed. Global DLL and FP16 changes still require a process restart because they alter the shared backend instance.
+- **`dll`**: Optional full path to `Lossless.dll`. Leave it unset to use
+  MAKO's normal Steam-library discovery.
+- **`allow_fp16`**: Enables half-precision acceleration where it is useful.
+  It is normally beneficial on AMD hardware; disable it for older NVIDIA GPUs
+  if performance is worse.
 
-HDR10 transport packing is automatic and has no setting. When both the application and backend Vulkan devices report
-the exact external-image and packed-storage capabilities required by the engine, the private source/output exchange
-images use 32-bit packed HDR10 instead of 64-bit float. PQ decoding, the frame-generation model, and all temporal working images
-remain linear 16-bit float. If either capability check fails, the validated float HDR10 transport remains in use.
+## Profile settings
 
-### Pacing Modes
+- **`name`**: Display name and value accepted by `MAKO_PROFILE`.
+- **`active_in`**: Executables or process names that select this profile.
+- **`multiplier`**: Fixed frame-generation multiplier, from 2x upward. The
+  direct Renderer default is `2`.
+- **`frame_generation_enabled`**: Live on/off switch. `false` presents real
+  frames while keeping the layer loaded. Default: `true`.
+- **`base_fps_cap`**: Caps the game's real frame rate before generation. `0`
+  disables the cap; direct configuration accepts 1–1000 FPS.
+- **`adaptive`**: Enables Adaptive Frame Generation. It varies generated
+  frames toward `target_fps` and ignores the fixed `multiplier`. Default:
+  `false`.
+- **`adaptive_auto_base_fps_cap`**: In Adaptive mode, caps the real frame rate
+  to half of `target_fps` for an even 2x baseline. It can trade real-frame
+  headroom and responsiveness for steadier output. Default: `false`.
+- **`target_fps`**: Adaptive displayed-frame-rate target. It is not a frame
+  limiter; MAKO cannot reduce a game already rendering above the target or
+  exceed the selected ceiling. Direct configuration accepts 10–1000. Default:
+  `120`.
+- **`adaptive_max_multiplier`**: Adaptive ceiling of 2x, 3x, or 4x. Start at
+  2x for image quality; use a higher ceiling only when the game benefits.
+  Default: `3`.
+- **`adaptive_stable_cadence`**: Prefers a constant interpolation cadence when
+  it is sustainable. It can look smoother but may increase input lag. Default:
+  `false`.
+- **`flow_scale`**: Motion-vector resolution from 0.25 to 1.0. Lower is faster;
+  higher favours image quality. Default: `1.0`.
+- **`performance_mode`**: Uses a lighter model for lower GPU cost and more
+  artifacts. Default: `false`.
+- **`pacing`**: Presentation policy. `none` is the only supported value.
+- **`gpu`**: Optional GPU name, vendor/device ID, or PCI bus ID. It must name
+  the GPU used by the game; multi-GPU frame generation is not supported.
 
-**Pacing modes** determine how MAKO Renderer synchronizes frame generation with the application's frame rate.
+MAKO Decky uses its own safer UI defaults—90 FPS Adaptive target, 0.90 Flow
+Scale, and Smooth Cadence enabled—when it creates a profile. Those defaults do
+not change the direct Renderer defaults above.
 
-V-Sync can help when it gives MAKO Renderer more evenly spaced real frames to work with, which can make generated output feel
-smoother. It can also add input lag or work poorly with a game's FPS cap, VRR, or compositor, so test it enabled and
-disabled for each game and keep the setting that feels best.
+## Applying changes
 
-For the normal SDR path, `none` uses MAKO Renderer's private FIFO output transport. The layer reserves swapchain capacity for
-generated images and presents the generated/real sequence in order. That output ordering is separate from the game's
-V-Sync setting. HDR-capable Gamescope swapchains preserve their separate WSI presentation contract, so this SDR detail
-does not describe the experimental HDR path.
+Frame Generation, Fixed/Adaptive mode, multiplier within existing capacity,
+Adaptive target/ceiling, and Smooth Cadence can usually apply while the game is
+running. Restart the game after changing the DLL path, FP16 policy, GPU, Flow
+Scale, Performance Mode, HDR-related settings, or a setting that requires more
+private GPU resources.
 
-Here are all available pacing modes:
-- `none`: Uses the established ordered SDR FIFO transport. It may require workarounds on some compositors.
-- *... there are no other pacing modes yet ...*
+Test V-Sync both on and off for each game. It can steady the real-frame cadence,
+but can also add latency or conflict with an FPS cap, VRR, or the compositor.
 
-### Environment Variables
+## Environment variables
 
-The following environment variables affect MAKO Renderer:
-- `ENABLE_MAKO`: Set to `1` in the MAKO launch wrapper to scope its uniquely named
-  implicit Vulkan layer to that game.
-- `DISABLE_MAKO`: If set to `1`, MAKO Renderer will be completely disabled.
-- `MAKO_CONFIG`: Path to the configuration file.
-- `MAKO_PROFILE`: Name of the profile to use. If set, this will override automatic profile detection.
-- `MAKO_DISABLE_HDR_EXPOSURE`: Set to `1` by the companion Decky plugin's default restart-time SDR launch, or by a
-  direct launcher that wants the same hard boundary. It overrides Gamescope/DXVK HDR capability and keeps every HDR
-  evidence path disabled for that process. HDR-capable launches do not
-  force the engine into HDR: application colour-space feedback or HDR metadata must still confirm application intent.
-- `MAKO_PRESENT_ACQUIRE_TIMEOUT_MS`: Optional timeout for generated-image acquisition. A timeout enters the
-  Gamescope presentation fallback; unset or `0` keeps the normal unbounded acquisition path.
-- `MAKO_PRESENT_DIAGNOSTICS`: Set to `1` to log slow presentation operations.
-- `MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS`: Minimum duration in milliseconds reported by presentation diagnostics.
+`ENABLE_MAKO=1` activates MAKO's implicit Vulkan layer only for the launched
+process. `DISABLE_MAKO=1` disables it. `MAKO_CONFIG` chooses a TOML file and
+`MAKO_PROFILE` chooses a named profile.
 
-If you do not wish to use a configuration file, you can also set configuration options through environment variables. To do this, set `MAKO_ENV=1` and then any of the following variables:
-- `MAKO_DLL_PATH`: Path to Lossless Scaling DLL.
-- `MAKO_NO_FP16`: If set to `1`, half-precision will be disabled.
-- `MAKO_MULTIPLIER`: Frame generation multiplier.
-- `MAKO_FRAME_GENERATION_ENABLED`: Set to `0` for live real-frame passthrough. Unlike
-  `DISABLE_MAKO`, the layer remains loaded.
-- `MAKO_ADAPTIVE`: Set to `1` to enable Adaptive Frame Generation.
-- `MAKO_TARGET_FPS`: Adaptive displayed-framerate target.
-- `MAKO_ADAPTIVE_MAX_MULTIPLIER`: Maximum Adaptive multiplier from `2` to `4`.
-- `MAKO_ADAPTIVE_STABLE_CADENCE`: Set to `1` to enable Smooth Cadence in Adaptive mode. It defaults to disabled.
-- `MAKO_FLOW_SCALE`: Flow scale value.
-- `MAKO_PERFORMANCE_MODE`: If set to `1`, performance mode will be enabled.
-- `MAKO_PACING`: Pacing mode to use.
-- `MAKO_GPU`: GPU to use for frame generation.
+For a configuration that comes entirely from environment variables, set
+`MAKO_ENV=1` and use any of the following:
+
+- `MAKO_DLL_PATH`, `MAKO_NO_FP16`, `MAKO_GPU`
+- `MAKO_MULTIPLIER`, `MAKO_FRAME_GENERATION_ENABLED`, `MAKO_BASE_FPS_CAP`
+- `MAKO_ADAPTIVE`, `MAKO_ADAPTIVE_AUTO_BASE_FPS_CAP`, `MAKO_TARGET_FPS`,
+  `MAKO_ADAPTIVE_MAX_MULTIPLIER`, `MAKO_ADAPTIVE_STABLE_CADENCE`
+- `MAKO_FLOW_SCALE`, `MAKO_PERFORMANCE_MODE`, `MAKO_PACING`
+
+`MAKO_DISABLE_HDR_EXPOSURE=1` keeps MAKO's unfinished HDR path disabled. It is
+the normal boundary used by the current Decky workflow.

--- a/engine/docs/FLATPAK-GUIDE.md
+++ b/engine/docs/FLATPAK-GUIDE.md
@@ -1,14 +1,11 @@
 # Flatpak guide
 
-MAKO Renderer builds separate Vulkan runtime extensions for Freedesktop 23.08,
-24.08, and 25.08. MAKO-branded Flatpak archives are not published yet; build
-them from this repository for direct use. When archives are published, install
-the bundle matching the target application's runtime.
+MAKO Renderer ships separate Vulkan runtime extensions for Freedesktop 23.08,
+24.08, and 25.08. Install the bundle matching the target application's runtime.
 
 ## Packaged extensions
 
-Extract a published or locally built MAKO Renderer Flatpak archive and install
-the matching bundle:
+Extract a MAKO Renderer Flatpak archive and install the matching bundle:
 
 ```bash
 tar -xJf mako-render-<version>-flatpaks.tar.xz

--- a/engine/docs/FLATPAK-GUIDE.md
+++ b/engine/docs/FLATPAK-GUIDE.md
@@ -1,10 +1,14 @@
 # Flatpak guide
 
-MAKO Renderer ships separate Vulkan runtime extensions for Freedesktop 23.08, 24.08, and 25.08. Install the bundle matching the target application's runtime.
+MAKO Renderer builds separate Vulkan runtime extensions for Freedesktop 23.08,
+24.08, and 25.08. MAKO-branded Flatpak archives are not published yet; build
+them from this repository for direct use. When archives are published, install
+the bundle matching the target application's runtime.
 
 ## Packaged extensions
 
-Extract a MAKO Renderer Flatpak archive and install the matching bundle:
+Extract a published or locally built MAKO Renderer Flatpak archive and install
+the matching bundle:
 
 ```bash
 tar -xJf mako-render-<version>-flatpaks.tar.xz

--- a/engine/docs/TROUBLESHOOTING.md
+++ b/engine/docs/TROUBLESHOOTING.md
@@ -1,141 +1,86 @@
 # Troubleshooting
-This page documents common issues, known incompatibilities and contains a guide to help you create a helpful bug report.
 
-Before reporting a bug, please read through the following sections to see if your issue is already addressed.
+## MAKO does not load
 
-### Basic Troubleshooting Steps
-If MAKO Renderer does not seem to be doing *anything*:
-- Ensure the game you are trying to run is using Vulkan (not OpenGL).
-- For a 32-bit game, ensure both `lib32/libmako-render.so` and
-  `VkLayer_MAKO_render.x86.json` were installed from the Linux
-  archive. The manifest must report `"library_arch": "32"`.
-- Install `vulkan-tools` and run
-  `ENABLE_MAKO=1 vulkaninfo | grep -i VK_LAYER_MAKO_render`.
-  - If there is no output revisit the installation steps.
-- Launch the game with the environment variable `VK_LOADER_DEBUG=layer` set.
-  - Look for `VK_LAYER_MAKO_render` and the
-    `mako: render layer active` build marker between `<Loader>` and `<Device>`.
-  - If you can't find any, try again using `MAKO_ENV=1`.
-    - If it still doesn't show up, you may be running in flatpak.
-    - If it does show up, then the `active_in` property of your profile is likely misconfigured. Reconfigure it, then try again without `MAKO_ENV=1`.
-- Check for warnings/errors from MAKO Renderer in the terminal/log output. These will often give clues as to what is going wrong.
-- If there are no errors/warnings and you have gone through all above steps, then move onto the next section.
+1. Confirm that the game uses Vulkan. MAKO does not attach to an OpenGL-only
+   process.
+2. Launch the game with `ENABLE_MAKO=1`. For Steam, use:
 
-If MAKO Renderer is loaded, but frame generation is not working:
-- (When using `pacing_mode = none`): Disable VRR.
-- (When using `pacing_mode = none`): Explicitly enable V-Sync in your game settings.
-- (When using `pacing_mode = none` on Gamescope/SteamDeck): Set `ENABLE_GAMESCOPE_WSI=0`.
-- (When using `pacing_mode = none` on Wayland): Disable tearing control & direct passthrough in your compositor
-- (When using `pacing_mode = none` on Wayland): Try running in windowed mode.
-- Disable in-game upscaling options (e.g. DLSS, FSR, etc).
-- Disable other Vulkan layers (e.g. VkBasalt, MangoHud)
+   ```text
+   ENABLE_MAKO=1 %command%
+   ```
 
-If games do not open at all with MAKO Renderer enabled for them (stuck at black screen):
-- Ensure you configured the correct `gpu` for this profile, in case you have multiple GPUs and/or drivers (mako-ui will show all available GPUs in a dropdown), MAKO Renderer might be defaulting to a different one than the game is using
+3. Check that the Vulkan loader can see the layer:
 
-Should none of the above help, please proceed to the bug reporting section.
+   ```bash
+   ENABLE_MAKO=1 vulkaninfo | grep -i VK_LAYER_MAKO_render
+   ```
 
-### Performance Overlays
-If you are using performance overlays like Steam's built-in overlay, there is a good chance that they will not show the correct framerate.
+   Install your distribution's Vulkan-tools package if `vulkaninfo` is
+   unavailable. No output usually means the layer manifest was not installed
+   in a Vulkan search path, the process is Flatpak-sandboxed, or the layer is
+   disabled by its launch environment.
+4. For a 32-bit game, install both `lib32/libmako-render.so` and
+   `VkLayer_MAKO_render.x86.json`. The manifest must report
+   `"library_arch": "32"`.
 
-This is a known limitation of Vulkan layers and without directly working with the overlay developers, there is little that can be done to fix this.
+Use `VK_LOADER_DEBUG=layer` with the normal launch command when you need to
+see Vulkan-loader decisions. Look for `VK_LAYER_MAKO_render` and the
+`mako: render layer active` message.
 
-### Opening a Bug Report
-When opening a bug report, please include the following information to help us diagnose and fix the issue:
-- A detailed description of the issue you are experiencing.
-- What system you are running on (OS, GPU, drivers, etc).
-- The game you are trying to run (and through what platform, e.g. Steam Proton, native Linux, etc).
-- The relevant section of your MAKO Renderer configuration file.
+## The layer loads but frame generation does not start
 
-Ideally, also include a log file with the environment variables `VK_INSTANCE_LAYERS=VK_LAYER_KHRONOS_validation` and `VK_LOADER_DEBUG=all` set. You might need to install the Vulkan validation layers package for your distribution to do this.
+- Confirm that Lossless Scaling is installed through Steam and that MAKO can
+  find `Lossless.dll`. Set `dll` in the configuration if the library is in a
+  non-standard Steam location.
+- Validate the configuration:
 
-If you're running the game through Steam, the log file is located at `~/.steam/steam/logs/console-linux.txt`. Please clear it before launching the game to ensure it only contains relevant information.
+  ```bash
+  mako-cli validate --config ~/.config/mako-render/conf.toml
+  ```
 
-### Diagnosing presentation stalls
+- Check the active profile. `active_in` must match the actual Linux binary,
+  Windows executable, process name, or path suffix. Set `MAKO_PROFILE` to a
+  known profile name to test profile matching explicitly.
+- On multi-GPU systems, the profile's `gpu` must identify the same GPU used by
+  the game.
+- Test the game's V-Sync both on and off. Also check its own FPS limiter, VRR,
+  and compositor settings before changing MAKO options.
 
-MAKO Renderer can log Vulkan presentation operations that take longer than expected. This is intended for
-targeted debugging and is disabled by default, so it has no effect on normal runs.
+For a Flatpak game or emulator, the host layer is not visible inside the
+sandbox. Install the matching MAKO Flatpak extension and application overrides
+as described in the [Flatpak guide](FLATPAK-GUIDE.md). MAKO Decky manages those
+steps through **Flatpak Setup**.
 
-Add `MAKO_PRESENT_DIAGNOSTICS=1` before the normal launch command. Operations taking at least 20 ms are written to
-Steam's `~/.steam/steam/logs/console-linux.txt` log. Override the threshold in milliseconds with
-`MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS`.
+## Collect diagnostics
 
-When using MAKO Decky, keep its wrapper in the launch option:
+Presentation diagnostics are off by default. Add the following before the
+normal launch command to log slow presentation operations:
 
 ```bash
-MAKO_PRESENT_DIAGNOSTICS=1 MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS=25 ~/.local/bin/mako-run %command%
+MAKO_PRESENT_DIAGNOSTICS=1 \
+MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS=25 \
+ENABLE_MAKO=1 your-game-command
 ```
 
-To test recovery from a stalled generated-image acquisition, add an opt-in timeout in milliseconds. If the timeout is
-reached, MAKO Renderer skips the remaining generated frames for that presentation and safely presents the original game
-frame. Following attempts probe image availability before scheduling output passes, so a Gamescope overlay cannot impose
-the full timeout or waste GPU work on generated frames that cannot be presented. A shared history-only pre-pass still
-updates the model's temporal features for every real frame instead of leaving older slots untouched.
-If zero-timeout probes keep missing
-the release window, the layer makes one bounded reacquisition attempt per second after the first second of fallback.
-The real game frames continue updating the two source images. Fixed mode resumes automatically as soon as a probe
-succeeds. By default, Adaptive mode first presents three real frames while repopulating its deepest temporal-history
-ring, then attempts generated output again. The same three-frame warm-up runs when an Adaptive context first starts.
-When Adaptive is capped at 2x and has already validated that level, a short hard gameplay hitch of up to 250 ms uses
-the same three-frame history refresh while retaining 2x. Longer interruptions retain the full menu/focus recovery.
-For example:
+For a Steam game, replace `your-game-command` with `%command%`. Steam captures
+the renderer's output in `~/.steam/steam/logs/console-linux.txt`; a direct
+desktop launch writes it to the terminal or launcher log.
 
-```bash
-MAKO_PRESENT_ACQUIRE_TIMEOUT_MS=25 MAKO_PRESENT_DIAGNOSTICS=1 MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS=25 ~/.local/bin/mako-run %command%
-```
+`MAKO_PRESENT_ACQUIRE_TIMEOUT_MS` is an experimental recovery diagnostic. Leave
+it unset for normal play. If you are reproducing a presentation stall, set a
+small value such as `25` and include the resulting log with the report.
 
-This recovery is experimental and disabled when `MAKO_PRESENT_ACQUIRE_TIMEOUT_MS` is absent or set to `0`.
-With diagnostics enabled, `skip-generated-frames` reports whether the fallback followed the initial timeout, a
-non-blocking retry, or a periodic `bounded-retry`. Its `backend_work` field records whether full output work was already
-`scheduled` or only the temporal `history-only` pre-pass ran. Expected repeated non-blocking failures are aggregated;
-Fixed-mode recovery uses `resume-generated-frames`. Adaptive recovery reports `generated-image-recovered`, followed by
-three `history-warmup` entries with `reason=recovery`. Adaptive startup uses the same entries with `reason=startup`.
-The recovery record includes the total number of frames whose output work was bypassed.
+## Report an issue
 
-Every successful Adaptive recovery probe stays in the current swapchain and performs the normal three-frame history
-warm-up. Diagnostics report `swapchain-recreation-suppressed reason=in-place-only` and
-`generated-image-recovered recovery_action=in-place`. MAKO Renderer does not return `VK_ERROR_OUT_OF_DATE_KHR` to apply a
-setting or recovery decision; this avoids game/Wine-specific swapchain rebuild failures. Fixed mode resumes in place
-without the Adaptive history-policy reset.
+Include the following:
 
-For a normal non-isolated installation, place the same environment variables before its usual launch command.
+- MAKO commit/version and installation method;
+- operating system, GPU, driver, compositor, and Proton version where relevant;
+- game, API path, resolution, and game settings;
+- the active MAKO profile with any private paths removed; and
+- the relevant MAKO/Vulkan-loader log lines.
 
-Clear the Steam log before reproducing the problem. After reproducing it, extract the most recent diagnostic entries
-with:
-
-```bash
-grep -aE 'mako: present diagnostics: operation=(runtime-transition-pending|runtime-state-applied|fixed-plan|adaptive-plan|adaptive-discontinuity|adaptive-stabilization|adaptive-gameplay-hitch|adaptive-fast-cadence-burst|adaptive-stable-cadence|adaptive-ramp|adaptive-recovery-resume-scheduled|adaptive-load-shed|adaptive-rescue|adaptive-bridge|adaptive-probe-aborted|adaptive-rearm|skip-generated-frames|generated-image-recovered|swapchain-recreation-suppressed|swapchain-context-create|swapchain-context-destroy)' ~/.steam/steam/logs/console-linux.txt | tail -n 800
-```
-
-`adaptive-stabilization` and `adaptive-ramp` show the normal restart sequence. `adaptive-load-shed` means a tested
-multiplier reduced useful throughput and was rolled back. `adaptive-bridge` is the single bounded test used when the
-first generated-frame step may have encountered a Gamescope cadence divisor. Its accepted/rejected record gives the
-measured result. `adaptive-rearm-scheduled` means another probe will wait at least 15 seconds and two stable seconds;
-`adaptive-rearm-ready` confirms those conditions were met. `swapchain-recreation-suppressed reason=first-recovery`
-confirms an isolated recovery remained in-place; `reason=cooldown` confirms the separate cross-context guard prevented
-a repeated recreation request.
-`adaptive-fast-cadence-burst` means an implausibly short DX12/Vulkan presentation interval was excluded from the base
-rate. Its aggregated frame counts and matching completion record show how long policy evaluation remained paused.
-`adaptive-gameplay-hitch-recovery` means a validated 2x Adaptive policy kept its level through a short gameplay hitch
-and refreshed temporal history instead of entering the longer menu/focus recovery path.
-Every presentation-diagnostic record includes a `context=<ID>` field. Use it to separate concurrent or replacement
-swapchains before comparing ramp, recovery, and presentation events; records with different context IDs may describe
-different windows or an old context being destroyed while its replacement starts.
-For HDR10, `HDR10 transport: mode=packed-10-bit` confirms that both Vulkan devices accepted the compact exchange path.
-`nominal_bytes_saved` is the exact reduction across the private transport images for that context; it is not a claimed
-whole-engine VRAM reduction. `mode=rgba16f` with either support field at `0` means the engine retained the validated
-float transport automatically. The model and its temporal working images remain 16-bit float in both cases.
-`activation_source=gamescope-app-colorspace` is the preferred Gamescope signal;
-`gamescope-app-hdr-metadata` is equivalent positive application evidence. `output_hdr=1` only confirms that the
-Gamescope output can expose HDR formats; it is not evidence that the application selected HDR and never promotes a
-swapchain by itself. If application feedback remains unset, a Gamescope-normalized high-precision swapchain remains in
-real-frame passthrough until positive application evidence arrives. Ordinary 8-bit SDR is never promoted.
-For a live-compatible in-game configuration change, `runtime-state-applied transition=live` records the requested state
-revision and the active mode. If a change needs different private GPU resources or HDR encoding,
-`runtime-transition-pending action=wait-for-natural-swapchain-recreation` records that it was deliberately not forced;
-the next naturally-created context reports `runtime-state-applied` with the same or a newer `state_revision`. Its
-`adaptive`, `target_fps`, multiplier, manual and effective Base FPS Cap, Adaptive Auto-Cap, Smooth Cadence, and `hdr`
-fields are the authoritative engine state; a Decky UI value alone does not prove the active context changed.
-
-Disable the diagnostic variables after collecting the trace. Remove the acquire-timeout and recreation variables too
-if you do not want to continue testing the recovery path.
+For Adaptive behaviour regressions, include the scenario and timing details.
+Maintainers can use the [Adaptive validation guide](ADAPTIVE-VALIDATION.md) for
+the full deterministic and runtime test matrix.

--- a/engine/scripts/publish-package.sh
+++ b/engine/scripts/publish-package.sh
@@ -11,15 +11,14 @@ flatpak_archive="out/mako-render-v$version-flatpaks.tar.xz"
 release_branch="$(git branch --show-current)"
 source_commit="$(git rev-parse HEAD)"
 release_remote="${MAKO_RELEASE_REMOTE:-origin}"
-notes_version="2.0.0-dev28-experimental.25"
-notes_previous_version="2.0.0-dev28-experimental.24"
-notes_previous_tag=""
 notes_tag_pattern="render-v*"
 
-if [[ "$version" != "$notes_version" ]]; then
-    echo "Release notes still describe $notes_version. Update scripts/publish-package.sh for $version before publishing." >&2
+if ! git remote get-url "$release_remote" >/dev/null 2>&1; then
+    echo "Release remote '$release_remote' is not configured." >&2
     exit 1
 fi
+
+git fetch "$release_remote" --tags --quiet
 
 latest_previous_tag=""
 while IFS= read -r candidate_tag; do
@@ -28,22 +27,15 @@ while IFS= read -r candidate_tag; do
         break
     fi
 done < <(git tag --merged HEAD --list "$notes_tag_pattern" --sort=-version:refname)
-if [[ -n "$notes_previous_tag" ]]; then
-    if ! git rev-parse -q --verify "refs/tags/$notes_previous_tag" >/dev/null; then
-        echo "Release-note baseline tag $notes_previous_tag is missing." >&2
-        exit 1
-    fi
-    if ! git merge-base --is-ancestor "$notes_previous_tag" HEAD; then
-        echo "Release-note baseline $notes_previous_tag is not an ancestor of HEAD." >&2
-        exit 1
-    fi
-    if [[ "$latest_previous_tag" != "$notes_previous_tag" ]]; then
-        echo "Release notes use $notes_previous_tag, but the latest prior MAKO Renderer tag is ${latest_previous_tag:-missing}. Update the baseline and change list before publishing." >&2
-        exit 1
-    fi
-elif [[ -n "$latest_previous_tag" ]]; then
-    echo "The MAKO Renderer release track already contains $latest_previous_tag. Set notes_previous_tag before publishing another render-v release." >&2
-    exit 1
+if [[ -n "$latest_previous_tag" ]]; then
+    release_notes_heading="What's new since \`$latest_previous_tag\`"
+    release_changes="$(git log --no-merges --format='- %s (%h)' "$latest_previous_tag"..HEAD -- engine README.md)"
+else
+    release_notes_heading="What's new in MAKO Renderer \`$version\`"
+    release_changes="$(git log --no-merges --format='- %s (%h)' HEAD -- engine README.md)"
+fi
+if [[ -z "$release_changes" ]]; then
+    release_changes='- No component-scoped changes were recorded after the previous tag.'
 fi
 
 if [[ "$release_branch" != "main" ]]; then
@@ -72,11 +64,6 @@ for command in gh git node; do
         exit 1
     fi
 done
-
-if ! git remote get-url "$release_remote" >/dev/null 2>&1; then
-    echo "Release remote '$release_remote' is not configured." >&2
-    exit 1
-fi
 
 release_repository="$(git remote get-url "$release_remote")"
 release_repository="${release_repository#git@github.com:}"
@@ -116,46 +103,23 @@ cat > "$notes_file" <<EOF
 
 ## Experimental Linux build
 
-This is a development build of the MAKO Renderer 2.x line. Test it game by game and retain a known-good rollback path.
+This is a MAKO Renderer prerelease. Test it game by game and retain a known-good rollback path.
 
-## What's new since \`$notes_previous_version\`
+## $release_notes_heading
 
-This \`.25\` release consolidates the tested SDR runtime, safer live configuration and recovery, and complete dual-architecture packaging. It also carries an HDR pipeline foundation for future testing; HDR frame generation is not presented as release-ready.
+$release_changes
 
-### Changes introduced in this release
+The list above is generated from every non-merge commit that changed MAKO
+Renderer or the shared README after the previous Renderer tag.
 
-#### SDR stability and live configuration
+### Before you install
 
-- Restores the established ordered SDR presentation path after introducing Gamescope-aware HDR transport. SDR and HDR now select separate colour, presentation, transition, and recovery policies so HDR experiments do not silently change ordinary SDR pacing.
-- Keeps real game frames native-first when generated-output resources or private GPU work are unavailable. Expected Gamescope image pressure does not schedule inference first, hold the present thread behind a refresh-length wait, or repeatedly reset Adaptive stabilization.
-- Preserves temporal-history liveness through startup, menu/focus transitions, generated-image pressure, and backend-busy frames. Recovery remains in-place and never invalidates a game-owned swapchain merely to apply a policy decision.
-- Makes configuration reloads resilient to transient partial TOML writes. Frame Generation, Fixed/Adaptive mode, Fixed multiplier within reserved capacity, Adaptive target and ceiling, and Smooth Cadence can update without rebuilding the game swapchain.
-- Keeps the load-aware Adaptive state machine, Smooth Cadence, menu/fast-cadence filtering, delayed-load rollback, and Fixed 2x/3x/4x paths covered by deterministic timing tests and the compatibility matrix.
-
-#### Host and Flatpak packaging
-
-- Ships architecture-matched ELF64 and ELF32 Vulkan layers and manifests in the host archive. The CLI and Qt UI remain 64-bit.
-- Ships both layer architectures in each Freedesktop 23.08, 24.08, and 25.08 Flatpak extension and verifies the deployed bundle paths before publishing.
-- Uses the uniquely named, environment-gated MAKO Renderer layer with an isolated installation path.
-
-#### HDR foundation for future releases
-
-- Classifies the complete Vulkan format/colour-space pair, with separate SDR 8-bit, SDR high-precision, HDR10/PQ, and linear-scRGB pipelines.
-- Includes explicit BT.2020/PQ to linear scRGB conversion around the model, plus a capability-validated packed HDR10 boundary transport that leaves model and temporal images at 16-bit float.
-- Resolves Gamescope application feedback away from the presentation hot path and requires application colour-space feedback or HDR metadata. Display HDR capability alone never promotes an SDR swapchain.
-- Keeps unsupported or unconfirmed encodings on real-frame passthrough. The companion Decky plugin sets \`MAKO_DISABLE_HDR_EXPOSURE=1\` as the engine's hard SDR boundary and leaves DXVK at its normal SDR default; direct launchers can set the same MAKO variable.
-- Treats this code as architecture and diagnostic groundwork. Cross-game HDR activation, colour validation, presentation and performance still require future hardware testing.
-
-### Important limitations
-
-- Adaptive Frame Generation is experimental and opt-in. This independent Vulkan-layer scheduler varies between zero and three generated frames per real frame toward the configured average target. It cannot reduce a native framerate already above the target, exceed the selected 4x maximum, guarantee an unreachable target, or provide the Windows Queue Target modes.
-- Higher interpolation ratios and lower real-frame rates can increase ghosting and input latency. Smooth Cadence can improve motion consistency but may lower real-frame cadence and responsiveness, so test it per game.
-- HDR frame generation is not release-ready in \`.25\`. The code is retained as disabled-by-default foundation and may fail to expose HDR, attach, generate, present, or perform acceptably in a particular game.
-- HDR10 conversion adds full-resolution GPU work. Packed boundary images reduce only the private exchange-image footprint; neither change is a universal performance claim.
-- HLG, Dolby Vision, and unvalidated wide-colour combinations intentionally use real-frame passthrough. A game still needs its own HDR renderer and an HDR-capable SteamOS/Gamescope session.
-- Lossless Scaling and \`Lossless.dll\` must already be installed through Steam; neither release archive includes or modifies it.
-- Gamescope generated-image admission is nonblocking and native-first. Recovery remains inside the existing context; the layer does not force game-owned swapchain recreation for a setting change or recovery decision.
-- Flatpak extensions for 23.08, 24.08, and 25.08 are packaged separately in \`$(basename "$flatpak_archive")\` under the dedicated MAKO Renderer extension ID.
+- Lossless Scaling and \`Lossless.dll\` must already be installed through Steam;
+  neither archive includes or modifies them.
+- Higher interpolation ratios can increase artifacts and input latency. Test each
+  game before relying on a new setting or release.
+- The host archive contains 64-bit and 32-bit Vulkan layers. The separate
+  Flatpak archive contains extensions for the supported runtimes.
 
 ### Included files
 
@@ -164,43 +128,12 @@ This \`.25\` release consolidates the tested SDR runtime, safer live configurati
 - 64-bit CLI and Qt configuration UI
 - XDG desktop files
 
-### Adaptive configuration
-
-Enable Adaptive mode through the Qt UI or a profile:
-
-\`\`\`toml
-adaptive = true
-target_fps = 120
-adaptive_max_multiplier = 3
-adaptive_stable_cadence = false
-frame_generation_enabled = true
-\`\`\`
-
-Frame Generation, Fixed/Adaptive mode, Fixed multiplier, Adaptive target, maximum multiplier, and Smooth Cadence can update live when the current context already reserved sufficient capacity. Restart after changing GPU, Flow Scale, Performance Mode, pacing, DLL, FP16 policy, or when increasing beyond the resources created at startup. HDR remains a separate experimental restart-time boundary.
-
-### Optional diagnostics
-
-Presentation diagnostics remain disabled by default. When enabled, slow Vulkan operations, fallback/recovery state, Adaptive ramp decisions, fast-cadence bursts, 2x gameplay-hitch recovery, and swapchain lifecycle events include a process-unique \`context=<ID>\` so concurrent or replacement contexts can be separated.
-
-With MAKO Renderer, enable diagnostics with this Steam launch option:
-
-\`\`\`bash
-MAKO_PRESENT_DIAGNOSTICS=1 MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS=25 ~/.local/bin/mako-run %command%
-\`\`\`
-
-After reproducing the problem, extract the latest diagnostic entries with:
-
-\`\`\`bash
-grep -aF "mako: present diagnostics:" ~/.steam/steam/logs/console-linux.txt | tail -n 800
-\`\`\`
-
-See the [presentation-stall troubleshooting guide](https://github.com/eugeniosegala/MAKO/blob/main/engine/docs/TROUBLESHOOTING.md#diagnosing-presentation-stalls) for recovery variables, event meanings, and focused filters. Disable diagnostics after collecting the trace.
-
 ### Install
 
 Download \`$(basename "$archive")\` and extract it to your local prefix:
 
 \`\`\`bash
+mkdir -p ~/.local
 tar -xJf $(basename "$archive") -C ~/.local
 \`\`\`
 
@@ -220,7 +153,6 @@ flatpak install --user org.freedesktop.Platform.VulkanLayer.makorender-24.08.fla
 
 - Source commit: \`$source_commit\`
 - SHA-256: \`$checksum\`
-- Renderer lineage version: \`2.0.0-dev28\`
 EOF
 
 if [[ "$tag_exists" == false ]]; then

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -11,13 +11,14 @@ MAKO Decky is the Decky Loader component of MAKO. It provides per-game controls,
 
 MAKO is an independent community project bringing Lossless Scaling frame generation to Linux today, with scaling support planned. It requires a user-supplied `Lossless.dll` from a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation. MAKO Decky does not bundle, copy, or modify that proprietary library.
 
-## Release status
+## Download
 
-MAKO Decky ZIPs are not published yet. The previous
-[Decky LSFG-VK Experimental releases](https://github.com/eugeniosegala/decky-lsfg-vk-experimental/releases)
-remain available, but their ZIPs, package names, and instructions use the old
-identity. Build a local MAKO ZIP with the development workflow below until the
-first MAKO release is available.
+Download the ZIP from the [latest MAKO Decky release](https://github.com/eugeniosegala/MAKO/releases/latest).
+Previous Decky releases are available on the
+[`plugin-v…` release track](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Aplugin-v).
+
+For direct Vulkan-layer installation without Decky, use the separate
+[MAKO Renderer release track](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Arender-v).
 
 ## What it manages
 

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -11,11 +11,13 @@ MAKO Decky is the Decky Loader component of MAKO. It provides per-game controls,
 
 MAKO is an independent community project bringing Lossless Scaling frame generation to Linux today, with scaling support planned. It requires a user-supplied `Lossless.dll` from a licensed [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/) installation. MAKO Decky does not bundle, copy, or modify that proprietary library.
 
-## Download
+## Release status
 
-Download the ZIP from the [latest MAKO Decky release](https://github.com/eugeniosegala/MAKO/releases/latest). Previous Decky releases are available on the [`plugin-v…` release track](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Aplugin-v).
-
-For direct Vulkan-layer installation without Decky, use the separate [MAKO Renderer release track](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Arender-v).
+MAKO Decky ZIPs are not published yet. The previous
+[Decky LSFG-VK Experimental releases](https://github.com/eugeniosegala/decky-lsfg-vk-experimental/releases)
+remain available, but their ZIPs, package names, and instructions use the old
+identity. Build a local MAKO ZIP with the development workflow below until the
+first MAKO release is available.
 
 ## What it manages
 

--- a/plugin/docs/CONFIGURATION.md
+++ b/plugin/docs/CONFIGURATION.md
@@ -1,143 +1,84 @@
 # Configuration guide
 
-The defaults are a good starting point: fixed **2x**, Flow Scale **0.90**, Performance Mode disabled, and FP16 allowed
-where supported. Adaptive mode defaults to a **90 FPS** target with **Smooth Cadence** enabled. Adaptive settings can be
-changed while a game is running, but the layer briefly resets its timing and stability calculations afterwards. Let it
-settle for a few seconds before judging performance. Fixed and Adaptive reserve one shared generated-frame capacity,
-so switching between them applies live when the selected multiplier/ceiling fits that capacity. The layer never forces
-the game to rebuild its swapchain for a UI change. The engine includes a private HDR/SDR resource transition for future
-HDR work, but this Decky release keeps HDR exposure locked off and therefore remains on the SDR resource path.
-Other GPU-backend, flow-scale, or performance-mode changes that cannot be applied safely remain pending until the game
-naturally recreates its swapchain or is restarted.
+The default profile is a good starting point: Fixed **2x**, Flow Scale **0.90**,
+Performance Mode off, and FP16 allowed where it is supported. Adaptive mode
+defaults to a **90 FPS** target, 3x ceiling, and Smooth Cadence on.
 
-## In-game V-Sync
+Test one change at a time. Games, displays, VRR, and compositors differ; try
+the game's V-Sync both on and off and keep the setting that feels smoother and
+more responsive.
 
-V-Sync can make MAKO Renderer feel smoother by giving it more evenly spaced real frames to work with. It can also add input
-lag or clash with a game's FPS cap, VRR, or compositor. Every game is different, so test V-Sync both on and off and
-keep the option that feels smoother and more responsive.
+## Frame generation
 
-For reference, Decky's established SDR path keeps generated and real frames in order before they reach the display.
-That engine detail is separate from the V-Sync option inside the game.
+- **Frame Generation (Live On/Off):** Turns synthesis on or off without losing
+  the selected Fixed or Adaptive settings.
+- **FPS Multiplier:** Fixed 2x, 3x, or 4x generation. Start at 2x for the
+  best balance of image quality and latency.
+- **Adaptive Frame Generation:** Varies the generated-frame count toward a
+  target. It is a target, not a game FPS limiter: it cannot reduce a game
+  already above target or exceed the selected ceiling.
+- **Target FPS:** Desired Adaptive output rate, from 30 to 240 FPS in Decky.
+- **Prefer Even 2x Baseline:** Caps real frames to half the Adaptive target for
+  steadier 2x-like motion. Adaptive can still use 3x or 4x when performance
+  falls. It can discard real-frame headroom and increase input latency, so it
+  is off by default.
+- **Maximum Adaptive Multiplier:** The 2x, 3x, or 4x Adaptive ceiling. 2x
+  usually looks best; 4x can help reach a higher target at the cost of more
+  generated frames.
+- **Smooth Cadence:** Prefers a sustainable constant interpolation cadence. It
+  can improve displayed motion but may reduce responsiveness. It is on by
+  default; disable it if the game feels better with stricter target scheduling.
+- **Base FPS Cap:** Caps real frames before generation. It applies live and is
+  disabled while **Prefer Even 2x Baseline** controls the cap.
 
-## Frame-generation mode
-
-- **Frame Generation (Live On/Off):** Leave this control on to use either Fixed or Adaptive Frame Generation. When
-  it is off, neither mode generates frames; your selected mode and settings remain saved for when you turn it back on.
-- **FPS Multiplier:** Fixed 2x, 3x, or 4x generation. Use the live **Frame Generation** switch to pass through real
-  frames without changing the selected mode. Under Gamescope, the engine uses the confirmed display refresh as a
-  delivery budget:
-  it suppresses synthetic frames that cannot be scanned out rather than letting a nominal 2x/3x/4x sequence run above
-  the display rate. This does not cap the game's real frames.
-- **Adaptive Frame Generation:** Optional mode that estimates the real frame rate and schedules zero to three generated
-  frames to approach the selected target. It replaces the fixed multiplier controls for that profile. Target, ceiling,
-  and Smooth Cadence changes apply live; expect a short settling period while Adaptive recalculates its timing.
-
-  **Live-change settling period:** Changing an Adaptive setting while a game is running resets its timing and stability
-  calculations. Give it a few seconds to settle before judging image quality, smoothness, or input responsiveness;
-  normal play can continue once it has settled.
-- **Target FPS:** 30–240 FPS. This setting is used only by Adaptive mode. It is a target, not a limiter: it cannot
-  reduce a game already running above target,
-  exceed the selected ceiling, or overcome GPU/model/compositor limits.
-- **Maximum Adaptive Multiplier:** Ceiling for generated frames: 2x, 3x, or 4x. 3x is the balanced default; 2x usually
-  gives the best image quality, while 4x gives Adaptive more headroom to reach the target. Test per game.
-- **Smooth Cadence:** Enabled by default in Adaptive mode. Strict scheduling settles first and constant cadence is
-  considered only when the target already needs nearly every matching cadence slot. It can make displayed motion look
-  smoother, but does so by holding a continuous generation level; this can lower the real-frame presentation cadence and
-  increase input lag. Leave it enabled where its visual smoothness is worthwhile; disable it when strict target
-  scheduling or responsiveness matters more for that game. After a severe sustained slowdown, Adaptive briefly
-  measures the real-only rate and either resumes fractional
-  scheduling or tests one higher level when **Maximum Adaptive Multiplier** permits it. Rescue never exceeds that
-  maximum and has a cooldown to avoid repeated switching.
-
-  **Per-game tuning:** There is no universal best mode. Compare Fixed 2x with Adaptive, then try Adaptive with Smooth
-  Cadence both enabled and disabled. The best choice depends on a game's frame pacing, real-frame headroom, display
-  refresh, and responsiveness, so change one setting at a time and let Adaptive settle before comparing results.
-
-Adaptive also has an automatic Steam-menu discontinuity safeguard, independent of **Smooth Cadence**. After a hard
-cadence stall, it temporarily presents real frames, waits for the measured base cadence to remain healthy for one
-second, and then restores the last proven generation level. If the old cadence does not recover within five seconds,
-Adaptive discards that stale baseline and ramps again from zero. A sustained gameplay cadence drop instead stabilizes
-for one second and rebases at the new measured rate, avoiding a five-second wait for an old rate that is no longer
-achievable. This can briefly reduce displayed FPS after leaving a menu, but avoids treating its transient frame rate as
-normal gameplay. After 2x has already proved stable, an isolated short gameplay hitch instead refreshes three real
-history frames and resumes 2x immediately. Fixed mode does not use these Adaptive policies.
+Adaptive target, ceiling, and cadence changes normally apply while a game is
+running. Give the game a few seconds to settle before judging the result.
+Changes that need a different GPU backend or larger private resources can wait
+for a natural swapchain recreation; restarting the game applies them directly.
 
 ## Profiles and per-game selection
 
-The plugin stores multiple MAKO Renderer profiles in its private `conf.toml`; it does not create a separate layer install or
-config file for every game. In the plugin's **Profile** section, choose **New Profile**, enter a name, and the plugin
-copies the selected profile's settings, then switches to the new profile. Configure it normally afterwards.
+Choose **New Profile** to copy the current profile, then adjust it for a game.
+Set **Active In** to the game's executable or process name to select that
+profile automatically at launch. It accepts comma-separated names, including
+Linux binaries and Windows `.exe` names.
 
-To select engine settings automatically for a game, enter its executable/process name in **Active In**. MAKO Renderer then
-matches the appropriate profile at launch. Once at least one profile has an **Active In** value, the wrapper leaves
-engine-profile selection to MAKO Renderer; you can return the UI selector to **Default** without breaking automatic matching.
-The following settings are profile-based and support that automatic match:
-
-- Live Frame Generation, Fixed multiplier or Adaptive mode, Target FPS, Maximum Adaptive Multiplier, and Smooth Cadence
-- Flow Scale, Performance Mode, GPU matching, and Active In
-
-The `Lossless.dll` path and FP16 permission are shared globally because they apply to the installed engine, not to an
-individual game.
-
-Decky also keeps the launcher compatibility options per profile—Disable MAKO Renderer on Next Launch, Disable
-Experimental HDR (Restart), Base FPS Cap, Steam Deck Mode, and Zink. They are saved in this plugin's private profile state and
-are restored when you select that profile in Decky. They cannot follow **Active In** automatically: those variables must
-be set by the wrapper before MAKO Renderer sees the game's process name. Select the profile manually before launching a game
-that needs one of those compatibility options, then restart the game after changing profiles.
+The frame-generation, quality, GPU, and Active In settings follow automatic
+profile matching. The DLL path and FP16 permission are global. Launcher
+compatibility settings—such as **Disable MAKO Renderer on Next Launch**,
+**Disable Experimental HDR**, Steam Deck Mode, and Zink—are selected before
+MAKO sees the game's process, so choose their Decky profile manually before
+launching when they differ between games.
 
 ## Quality and matching
 
-- **Flow Scale:** 0.25–1.0. Lower values generally reduce GPU cost; higher values favour optical-flow quality.
-- **Performance Mode:** Uses a lighter model with lower GPU overhead and more artifacts. For the best v2 image quality,
-  start with it disabled.
-- **Allow FP16:** Allows half-precision processing on supported GPUs. It can improve performance; results vary by game
-  and driver.
-- **Lossless.dll Path:** Override detection when necessary. Leaving it blank allows MAKO Renderer discovery.
-- **Active In:** Optional comma-separated executable/process matching. If set, MAKO Renderer selects matching profiles
-  automatically.
-- **GPU:** Optional GPU identifier for multi-GPU systems.
+- **Flow Scale:** 0.25–1.0. Lower values reduce GPU cost; higher values favour
+  optical-flow quality.
+- **Performance Mode:** Uses a lighter model with lower GPU overhead and more
+  visible artifacts.
+- **Allow FP16:** Usually improves performance on AMD. Disable it if an older
+  NVIDIA GPU performs worse.
+- **Lossless.dll Path:** Overrides automatic discovery. Leave it empty for
+  normal Steam-library discovery.
+- **GPU:** Optional GPU name, vendor/device ID, or PCI bus ID. It must identify
+  the GPU used by the game; dual-GPU frame generation is not supported.
 
-## Compatibility options
+## Compatibility and HDR
 
-The bundled engine includes matching 64-bit and 32-bit Vulkan layers. The Vulkan loader selects the correct layer for
-the game's process, so native 32-bit Vulkan games do not require a WoW64 launcher option. The CLI and configuration UI
-remain 64-bit because they are not loaded into the game process.
+The package includes 64-bit and 32-bit Vulkan layers. Vulkan chooses the right
+layer for the game process; the CLI and configuration UI are 64-bit only.
 
-- **Disable MAKO Renderer on Next Launch:** Compatibility troubleshooting only. Prevents the MAKO Renderer
-  Vulkan layer from loading when the game next starts, so you can test without it or bypass a startup/attachment
-  problem. This requires a game restart. It is different from **Frame Generation**, which switches synthesis on or off
-  live while the layer remains loaded.
-- **Base FPS Cap:** Optionally caps the base DirectX framerate before multiplication.
-- **Steam Deck Mode:** A per-game compatibility path.
-- **Zink:** Optional Vulkan-based OpenGL path for OpenGL games.
+- **Disable MAKO Renderer on Next Launch:** Troubleshooting control that stops
+  the layer loading after restart. Use **Frame Generation** for a live on/off
+  test instead.
+- **Steam Deck Mode:** Per-game compatibility path.
+- **Zink:** Vulkan-based OpenGL path for OpenGL games.
 
-Gamescope WSI and MangoHud controls are deliberately not shown. The wrapper enables MAKO Renderer's uniquely named
-layer for that game. In this release, **Disable Experimental HDR
-(Restart)** is checked and read-only: the wrapper exports `MAKO_DISABLE_HDR_EXPOSURE=1` and leaves DXVK at its normal
-SDR default. Heroic Flatpak launches explicitly keep Gamescope WSI ahead of MAKO Renderer so compositor
-presentation and frame limiting remain available. Existing profiles that previously opted into HDR are normalized back
-to this stable SDR boundary when loaded or saved.
+HDR frame generation remains under development. **Disable Experimental HDR
+(Restart)** is intentionally checked and read-only: MAKO Decky keeps the
+renderer on its validated SDR path without changing the game's normal DXVK or
+Gamescope policy. Do not add HDR environment variables manually for ordinary
+launches. Use **Disable MAKO Renderer on Next Launch** if the layer itself is
+the suspected problem.
 
-### HDR launch boundary
-
-These controls belong to different components and are deliberately kept separate:
-
-| Setting | Owner | Behaviour in this release |
-| --- | --- | --- |
-| `MAKO_DISABLE_HDR_EXPOSURE=1` | MAKO Renderer | Blocks this layer's unfinished HDR exposure and transition path. It does not configure the game's renderer or system HDR. |
-| `DXVK_HDR` | DXVK | The wrapper unsets it instead of forcing `0`, leaving DXVK at its normal SDR default and avoiding a plugin-wide renderer override. |
-| `ENABLE_GAMESCOPE_WSI` | Gamescope | The wrapper preserves the launcher's value and keeps Gamescope's manifest available in Heroic. It never disables Gamescope to enforce MAKO Renderer's HDR boundary. |
-
-This means the plugin can keep its own HDR work disabled without changing DXVK policy or removing Gamescope's normal
-presentation and frame-limiting integration. Users should not add any of these variables manually for an ordinary SDR
-launch.
-
-HDR frame generation remains under development. The pinned engine contains format classification, HDR10/PQ and
-linear-scRGB conversion, Gamescope feedback, packed-boundary transport, and safe-passthrough groundwork, but the Decky
-launcher does not expose that path in `.25`. In-game HDR controls may therefore be disabled; this is expected. A future
-release will unlock the control only after activation, presentation, colour, and performance are validated across
-games. Use
-**Disable MAKO Renderer on Next Launch** when the layer itself is the suspected cause. The plugin
-writes `pacing = 'none'` and does not expose a
-dual-GPU control. See
-[Troubleshooting](TROUBLESHOOTING.md) and the release notes for build-specific compatibility guidance.
+See [Troubleshooting](TROUBLESHOOTING.md) for diagnostics and update recovery.

--- a/plugin/docs/PACKAGING.md
+++ b/plugin/docs/PACKAGING.md
@@ -2,18 +2,21 @@
 
 ## Build a local installation ZIP
 
-Install pnpm and dependencies once. With Volta, run `volta install pnpm` first.
+Run the commands in this guide from the `plugin/` directory. Install pnpm and
+dependencies once; with Volta, run `volta install pnpm` first.
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm run package:local
 ```
 
-This creates `out/Mako.zip`. The packager regenerates configuration bindings, builds the
-frontend, builds the sibling MAKO Renderer engine, verifies its payload, and creates a Decky ZIP. It
-does not tag, push, or publish anything.
+This creates a versioned local ZIP under `out/`, named
+`Mako-local.<engine-and-source-identity>.zip`. The packager regenerates
+configuration bindings, builds the frontend and sibling MAKO Renderer engine,
+verifies its payload, and creates a Decky ZIP. It does not tag, push, or
+publish anything.
 
-`Mako.zip`, the ZIP's `Mako/` directory, and the installed
+The ZIP's `Mako/` directory and the installed
 `~/homebrew/plugins/Mako` directory match the **Mako** name displayed inside
 Decky. The component is officially named **MAKO Decky** within the wider MAKO
 project.
@@ -24,15 +27,21 @@ Pass a path to choose the output location:
 pnpm run package:local -- /path/to/Mako.zip
 ```
 
-To test an engine candidate before its GitHub release exists, provide locally built native and Flatpak archives. Their
-checksums must still match the pin in `package.json`:
+To reuse local copies of the *already pinned* Renderer and Flatpak archives,
+provide both archives directly. Their filenames and checksums must match the
+pin in `package.json`:
 
 ```bash
-pnpm run package:local -- \
+scripts/package-local.sh \
   --engine-archive /path/to/mako-render-<version>-linux.tar.xz \
   --flatpak-archive /path/to/mako-render-<version>-flatpaks.tar.xz \
   /path/to/Mako-local-test.zip
 ```
+
+For an engine candidate that differs from the pin, use
+`pnpm run package:local-engine` or `scripts/package-local.sh --local-engine-repo
+/path/to/MAKO/engine`. That workflow creates and records a local payload
+identity in the ZIP instead of pretending it is a released archive.
 
 ### Build directly from a local engine checkout
 
@@ -149,8 +158,29 @@ compiler prerequisites in the [source-build guide](../../engine/docs/BUILDING-FR
 
 ## Publish a GitHub release
 
-Commit the intended version and release changes on a clean branch, authenticate once with
-`gh auth login -h github.com`, then run:
+> [!IMPORTANT]
+> No MAKO Renderer or MAKO Decky release has been published yet. This is the
+> future release procedure; do not run it for a local test ZIP.
+
+Publish from a clean `main` worktree and authenticate once with
+`gh auth login -h github.com`. Both publishers intentionally refuse another
+branch or uncommitted changes.
+
+1. Update the Renderer version and its version-specific release-note values in
+   `engine/scripts/publish-package.sh`, then commit the intended Renderer
+   release on `main`.
+2. From `engine/`, run:
+
+   ```bash
+   ./scripts/publish-package.sh
+   ```
+
+   This creates the `render-v<version>` prerelease, uploads the native and
+   Flatpak archives, and updates `plugin/package.json` with their verified
+   checksums.
+3. Review and commit that generated Renderer pin. Update the Decky version and
+   its version-specific release-note values in `plugin/scripts/publish-package.sh`.
+4. From `plugin/`, run:
 
 ```bash
 pnpm run package:publish
@@ -167,15 +197,11 @@ published as a normal GitHub release even when its component version contains
 an `experimental` suffix. MAKO Renderer releases remain GitHub prereleases and
 are explicitly published with `--latest=false`.
 
-The publisher requires `plugin/package.json` to pin checksum-verified
-`mako-render-v<version>-linux.tar.xz` and
-`mako-render-v<version>-flatpaks.tar.xz` assets from the matching
-`render-v<version>` release in this repository. Publish MAKO Renderer first,
-then review and commit the renderer publisher's automatic `plugin/package.json`
-update before publishing MAKO Decky. The generated pin records the renderer
-tag, source commit, repository, asset names, URLs, and SHA-256 checksums.
+The Decky publisher requires `plugin/package.json` to pin the matching
+checksum-verified Renderer assets. It refuses a local-only payload or an
+unpublished/mismatched Renderer tag.
 
-Release entry points:
+After the first release, the release entry points will be:
 
 - [Latest MAKO Decky release](https://github.com/eugeniosegala/MAKO/releases/latest)
 - [All MAKO Decky releases](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Aplugin-v)

--- a/plugin/docs/PACKAGING.md
+++ b/plugin/docs/PACKAGING.md
@@ -158,17 +158,17 @@ compiler prerequisites in the [source-build guide](../../engine/docs/BUILDING-FR
 
 ## Publish a GitHub release
 
-> [!IMPORTANT]
-> No MAKO Renderer or MAKO Decky release has been published yet. This is the
-> future release procedure; do not run it for a local test ZIP.
-
 Publish from a clean `main` worktree and authenticate once with
 `gh auth login -h github.com`. Both publishers intentionally refuse another
 branch or uncommitted changes.
 
-1. Update the Renderer version and its version-specific release-note values in
-   `engine/scripts/publish-package.sh`, then commit the intended Renderer
-   release on `main`.
+Both publishers fetch the remote component tags and generate a release-note
+commit list from the latest earlier tag. Review that list before publishing; it
+contains every non-merge commit that touched the component or shared README in
+the selected range.
+
+1. Update the Renderer version and commit the intended Renderer release on
+   `main`.
 2. From `engine/`, run:
 
    ```bash
@@ -178,8 +178,8 @@ branch or uncommitted changes.
    This creates the `render-v<version>` prerelease, uploads the native and
    Flatpak archives, and updates `plugin/package.json` with their verified
    checksums.
-3. Review and commit that generated Renderer pin. Update the Decky version and
-   its version-specific release-note values in `plugin/scripts/publish-package.sh`.
+3. Review and commit that generated Renderer pin, then update and commit the
+   Decky version.
 4. From `plugin/`, run:
 
 ```bash
@@ -201,7 +201,7 @@ The Decky publisher requires `plugin/package.json` to pin the matching
 checksum-verified Renderer assets. It refuses a local-only payload or an
 unpublished/mismatched Renderer tag.
 
-After the first release, the release entry points will be:
+Release entry points:
 
 - [Latest MAKO Decky release](https://github.com/eugeniosegala/MAKO/releases/latest)
 - [All MAKO Decky releases](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Aplugin-v)

--- a/plugin/docs/TROUBLESHOOTING.md
+++ b/plugin/docs/TROUBLESHOOTING.md
@@ -1,77 +1,55 @@
 # Troubleshooting
 
-## HDR (in progress)
+These instructions apply to local MAKO Decky ZIPs until the first MAKO release
+is published.
 
-HDR exposure is intentionally unavailable in this Decky release. **Disable Experimental HDR (Restart)** is checked,
-read-only, and enforced by the backend even if an older profile stored the opposite value. The generated wrapper exports
-`MAKO_DISABLE_HDR_EXPOSURE=1` and leaves DXVK at its normal SDR default. Heroic Flatpak launches retain Gamescope WSI
-alongside MAKO Renderer. An HDR option being unavailable inside a game is therefore expected and is not
-evidence that the `.25` package installed incorrectly.
+## HDR is unavailable by design
 
-The pinned engine still contains the HDR10/PQ and linear-scRGB colour-pipeline foundation, Gamescope feedback resolver,
-packed HDR10 boundary transport, and safe-passthrough diagnostics. Those pieces remain useful for continued engine
-development, but Decky will not expose them until cross-game activation, presentation, colour, and performance have
-been validated. The diagnostics helper retains its `hdr` preset for that future testing; ordinary `.25` Decky runs
-should remain on SDR.
+HDR frame generation is still under development. **Disable Experimental HDR
+(Restart)** is checked, read-only, and enforced by the backend. The launcher
+uses MAKO's validated SDR path, so an HDR option being unavailable in a game is
+expected and does not mean the ZIP installed incorrectly.
 
-If MAKO Renderer prevents a title from starting, use **Disable MAKO Renderer on Next
-Launch** and restart the game. That control is separate from the locked HDR safety boundary.
+Use **Disable MAKO Renderer on Next Launch** and restart the game if you need
+to test whether the layer is the cause of a startup or presentation problem.
 
-## Steam menu / Gamescope recovery
+## A game will not start or MAKO appears inactive
 
-The engine's developing Gamescope HDR transport reserves generated destinations with timeout zero before scheduling
-model work, but that transport is not exposed by this Decky release. Current Decky launches use the proven SDR
-transport, which intentionally retains ordered FIFO and synchronous fence behaviour. Applying the opportunistic HDR
-bypass to SDR caused generated frames to be skipped on ordinary one-frame overlap on Deck-class hardware, so the two
-paths remain separate.
+1. For a native Steam or Proton game, confirm its launch option is exactly:
 
-Recovery never returns a fabricated out-of-date result merely to make the game rebuild its swapchain. The engine keeps
-ordered SDR and its future Gamescope HDR path on different policies. SDR refreshes two real history frames after a cadence discontinuity
-and retains the last proven multiplier; sustained model-load collapse falls directly to the cheaper proven generated
-level, while validated 2x is retained rather than inserting a visible real-only second. The inactive HDR foundation
-uses more conservative bounded discontinuity recovery because a stall can also mean colour-transition or
-compositor-admission pressure. It
-presents real frames until healthy base cadence has returned for one second, restores the proven level, or starts a
-clean ramp after the bounded timeout. This separation prevents HDR safety guards from degrading the established SDR
-path.
+   ```text
+   ~/.local/bin/mako-run %command%
+   ```
 
-When Adaptive is capped at 2x and has already validated that level, a short gameplay hitch of up to 250 ms takes a
-lighter path: the engine keeps the proven 2x policy, refreshes three real frames of temporal history, and resumes.
-Longer interruptions retain the full menu/focus recovery described above.
+2. Open Mako and select **Install MAKO Renderer (developer build)**. Installing
+   a Decky ZIP alone does not replace the private Renderer payload.
+3. Check the selected profile's `Lossless.dll` path, GPU choice, and **Active
+   In** rule. Start with Fixed 2x before testing Adaptive settings.
+4. Test the game's V-Sync both on and off. Its own FPS limiter, VRR, or
+   compositor configuration can affect frame pacing.
 
-If the menu interrupts an Adaptive ramp or bridge test, the engine now treats that probe as incomplete rather than
-failed and rearms it after two stable seconds. A probe that genuinely fails its throughput checks retains a 15-second
-cooldown, with an earlier retry only after a sustained 15% real-only base-rate improvement.
+For Heroic, keep the **Wrapper** as `/home/deck/.local/bin/mako-run`, leave
+**Arguments** empty, and add no `%command%`. For a Flatpak emulator such as
+Dolphin, prepare the application in **Flatpak Setup** and start it normally;
+do not add the Steam wrapper manually.
 
-Adaptive also stops at the lowest proven multiplier that can already supply at least 95% of the requested target. If a
-newly accepted higher multiplier later causes a sustained real-frame collapse, the engine briefly measures cadence
-without generated-frame work. It returns to the lower proven multiplier only when that measurement recovers the prior
-rate; otherwise it keeps the higher multiplier because the game scene itself became more demanding. This prevents an
-unnecessary 3x load from remaining slower than a capable fixed 2x path while avoiding false backoff in heavy scenes.
+## Collect diagnostics
 
-## Collecting diagnostics
-
-Published builds keep diagnostics off by default. Local development ZIPs made with `--local-plugin`,
-`package:local-engine`, or `package:local-engine-fast`, and direct `dev:*` deployments, enable them automatically.
-They are written to the plugin-private file below, rather than Steam's cumulative console log. Starting a game with
-diagnostics enabled replaces the previous diagnostic file, so it contains one current test run. Set
-`MAKO_PRESENT_DIAGNOSTICS=0` in a game's environment when a development build needs a clean profiling run.
-
-For a Steam game, temporarily replace the normal launch option with:
+Published builds keep diagnostics off by default. Local development ZIPs and
+direct `dev:*` deployments enable them automatically. To collect a focused
+Steam report, temporarily replace the game's normal launch option with:
 
 ```text
 MAKO_PRESENT_DIAGNOSTICS=1 MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS=25 ~/.local/bin/mako-run %command%
 ```
 
-For a Heroic game, leave its **Wrapper** as `/home/deck/.local/bin/mako-run` and leave **Arguments**
-empty. Under the game's **Environment Variables**, add these two name/value rows:
+For Heroic, keep the normal Wrapper and Arguments fields. Add these two
+environment variables in the game's settings instead:
 
 ```text
 MAKO_PRESENT_DIAGNOSTICS=1
 MAKO_PRESENT_DIAGNOSTICS_THRESHOLD_MS=25
 ```
-
-Do not put `%command%` or either variable in Heroic's Wrapper or Arguments fields.
 
 Reproduce the issue, quit the game, then run this in Desktop Mode:
 
@@ -79,63 +57,29 @@ Reproduce the issue, quit the game, then run this in Desktop Mode:
 ~/.local/bin/mako-diagnostics all
 ```
 
-The plugin installs that read-only helper beside its launch wrapper and refreshes it automatically when the plugin is
-loaded. It selects the plugin-private log first and falls back to Steam's console log if necessary. Choose one or more
-presets to produce a smaller report:
-
-```bash
-# Was HDR10/PQ or linear scRGB selected, and was packed HDR10 transport enabled?
-~/.local/bin/mako-diagnostics hdr
-
-# Did a Decky change apply live or wait safely for natural recreation?
-~/.local/bin/mako-diagnostics config
-
-# Target selection, stabilization, cadence, ramp, load shedding, bridge and rescue.
-~/.local/bin/mako-diagnostics adaptive
-
-# Generated-image timeout, real-frame fallback, history warm-up and in-place recovery.
-~/.local/bin/mako-diagnostics recovery
-
-# Fixed multiplier/input-output telemetry plus slow GPU/presentation operations.
-~/.local/bin/mako-diagnostics performance
-
-# Vulkan layer discovery, Gamescope WSI, swapchain context and colour selection.
-~/.local/bin/mako-diagnostics startup
-
-# Failures, timeouts, fallbacks, passthrough and Vulkan errors.
-~/.local/bin/mako-diagnostics errors
-
-# Combine related views without collecting unrelated Adaptive policy traffic.
-~/.local/bin/mako-diagnostics hdr config adaptive recovery performance errors
-
-# Every relevant MAKO, Vulkan-loader, and Gamescope WSI line from the run.
-~/.local/bin/mako-diagnostics --lines 2000 all > ~/mako-report.txt
-```
-
-Run `~/.local/bin/mako-diagnostics --help` for the complete preset list. Use `--log PATH` to inspect a
-specific saved log and `--lines N` to change the output limit. Presets only filter an existing log; they do not enable
-diagnostics or change the game configuration.
-
-If the helper is unavailable, these raw commands provide the two most common reports:
-
-```bash
-# HDR selection, private transition, and safe fallback.
-grep -aE 'mako: (Gamescope application HDR feedback|swapchain colour pipeline|HDR10 transport|frame generation disabled|MAKO frame-generation initialization failed)|mako: present diagnostics: operation=(runtime-transition-pending|runtime-transition-applied|runtime-state-applied|gamescope-refresh-rate-applied)' ~/.config/mako-render/present-diagnostics.log | tail -n 200
-
-# Adaptive policy and Gamescope recovery.
-grep -aE 'mako: present diagnostics: operation=(runtime-transition-pending|runtime-transition-applied|runtime-state-applied|gamescope-refresh-rate-applied|generated-delivery-miss|fixed-plan|adaptive-|skip-generated-frames|resume-generated-frames|generated-image-recovered|history-warmup|swapchain-recreation-suppressed|swapchain-context-create|swapchain-context-destroy)' ~/.config/mako-render/present-diagnostics.log | tail -n 800
-```
-
-Remove the temporary Steam launch variables or Heroic environment rows afterwards: diagnostics can generate substantial
-log traffic. Local development builds return to automatic collection when that explicit override is removed.
+Useful focused reports are `mako-diagnostics adaptive`, `recovery`,
+`performance`, `startup`, and `errors`. Add `--lines 2000` when the normal
+output is too short, or `--log PATH` for a saved diagnostic log. Remove the
+temporary variables afterwards because they can generate substantial log
+traffic.
 
 ## Update and Flatpak checks
 
-After installing a new plugin ZIP, select **Install MAKO Renderer (developer build)**. ZIP installation updates
-the plugin files but does not replace the private native engine by itself.
+Use the clean update path for every newer local ZIP:
 
-For Heroic, also open **Flatpak Setup** and select **Update** for Heroic's matching runtime extension—usually 25.08. Do
-not disable Heroic preparation or remove its per-game Wrapper command merely to update the extension.
+1. Quit games using `mako-run`.
+2. Uninstall **Mako** from Decky and install the newer ZIP through
+   **Developer > Install Plugin from Zip**.
+3. Restart the Steam Deck or Steam Machine.
+4. Open Mako and select **Install MAKO Renderer (developer build)**.
+5. In **Flatpak Setup**, select **Update** for every prepared application's
+   matching runtime extension, such as Heroic or Dolphin.
 
-If Decky does not show or reload a ZIP update, uninstall Mako from Decky, install the ZIP again,
-restart your Steam Deck or Steam Machine, then install the private engine again.
+This preserves profiles and launch options while replacing the private native
+Renderer and refreshing any shared Flatpak extensions.
+
+## Report an issue
+
+Include the MAKO ZIP/commit, SteamOS or Linux version, GPU and driver, game and
+Proton version, selected profile, exact launch method, and the relevant
+diagnostic report. Remove personal paths before sharing configuration or logs.

--- a/plugin/docs/TROUBLESHOOTING.md
+++ b/plugin/docs/TROUBLESHOOTING.md
@@ -1,7 +1,7 @@
 # Troubleshooting
 
-These instructions apply to local MAKO Decky ZIPs until the first MAKO release
-is published.
+These instructions apply to both published MAKO Decky ZIPs and local developer
+builds.
 
 ## HDR is unavailable by design
 

--- a/plugin/plugin.json
+++ b/plugin/plugin.json
@@ -5,7 +5,7 @@
   "api_version": 1,
   "publish": {
     "tags": ["installer", "vulkan", "mako", "framegen", "lossless-scaling", "scaling", "steam-machine"],
-    "description": "Next-generation Vulkan-powered graphics for Linux gaming, bringing Lossless Scaling frame generation and scaling to Steam Deck and desktop Linux.",
+    "description": "MAKO brings Vulkan-powered Lossless Scaling frame generation to Steam Deck, Steam Machine, and SteamOS gaming.",
     "image": "https://raw.githubusercontent.com/eugeniosegala/MAKO/refs/heads/main/plugin/assets/mako-logo.png"
   }
 }

--- a/plugin/scripts/publish-package.sh
+++ b/plugin/scripts/publish-package.sh
@@ -99,16 +99,10 @@ read -r archive_name engine_version package_version github_repository has_flatpa
   ' "$project_dir/package.json"
 )
 
-notes_package_version="0.13.0-experimental.25"
-notes_engine_version="2.0.0-dev28-experimental.25"
-notes_previous_package_version="0.13.0-experimental.24"
 plugin_release_tag="plugin-v$package_version"
-notes_previous_package_tag=""
 notes_package_tag_pattern="plugin-v*"
-if [[ "$package_version" != "$notes_package_version" || "$engine_version" != "$notes_engine_version" ]]; then
-  echo "Release notes still describe plugin $notes_package_version with engine $notes_engine_version. Update them before publishing." >&2
-  exit 1
-fi
+git -C "$project_dir" fetch origin --tags --quiet
+
 latest_previous_package_tag=""
 while IFS= read -r candidate_tag; do
   if [[ "$candidate_tag" != "$plugin_release_tag" ]]; then
@@ -116,22 +110,15 @@ while IFS= read -r candidate_tag; do
     break
   fi
 done < <(git -C "$project_dir" tag --merged HEAD --list "$notes_package_tag_pattern" --sort=-version:refname)
-if [[ -n "$notes_previous_package_tag" ]]; then
-  if ! git -C "$project_dir" rev-parse -q --verify "refs/tags/$notes_previous_package_tag" >/dev/null; then
-    echo "Release-note baseline tag $notes_previous_package_tag is missing." >&2
-    exit 1
-  fi
-  if ! git -C "$project_dir" merge-base --is-ancestor "$notes_previous_package_tag" HEAD; then
-    echo "Release-note baseline $notes_previous_package_tag is not an ancestor of HEAD." >&2
-    exit 1
-  fi
-  if [[ "$latest_previous_package_tag" != "$notes_previous_package_tag" ]]; then
-    echo "Release notes use $notes_previous_package_tag, but the latest prior MAKO Decky tag is ${latest_previous_package_tag:-missing}. Update the baseline and change list before publishing." >&2
-    exit 1
-  fi
-elif [[ -n "$latest_previous_package_tag" ]]; then
-  echo "The MAKO Decky release track already contains $latest_previous_package_tag. Set notes_previous_package_tag before publishing another plugin-v release." >&2
-  exit 1
+if [[ -n "$latest_previous_package_tag" ]]; then
+  release_notes_heading="What’s new since \`$latest_previous_package_tag\`"
+  release_changes="$(git -C "$repository_root" log --no-merges --format='- %s (%h)' "$latest_previous_package_tag"..HEAD -- plugin README.md)"
+else
+  release_notes_heading="What’s new in MAKO Decky \`$package_version\`"
+  release_changes="$(git -C "$repository_root" log --no-merges --format='- %s (%h)' HEAD -- plugin README.md)"
+fi
+if [[ -z "$release_changes" ]]; then
+  release_changes='- No Decky- or shared-documentation changes were recorded after the previous tag.'
 fi
 if [[ "$archive_url" == local-only://* || "$engine_release_tag" == local-only-* ]]; then
   echo "Refusing to publish a package pinned to a local-only engine payload." >&2
@@ -211,27 +198,22 @@ notes_file="$notes_dir/release-notes.md"
 printf '%s\n' \
   '> Looking for the standalone Vulkan layer? See the [MAKO Renderer releases](https://github.com/eugeniosegala/MAKO/releases?q=tag%3Arender-v).' \
   '' \
-  "## What’s new since \`$notes_previous_package_version\`" \
+  "## $release_notes_heading" \
   '' \
-  '- **Engine update:** Bundles checksum-verified MAKO Renderer `2.0.0-dev28-experimental.25`. Complete the required in-plugin engine-update step after installing the ZIP.' \
-  '- **HDR foundation — in progress:** The bundled engine contains HDR10/PQ and linear-scRGB colour-pipeline groundwork, Gamescope feedback, packed HDR10 boundary transport, and safe passthrough. HDR activation and frame generation are not exposed by this Decky release while cross-game presentation, colour, and performance validation continues.' \
-  '- **64-bit and 32-bit Vulkan support:** Installs architecture-matched host and Flatpak layers. Vulkan selects the correct layer for each game process, so genuine 32-bit Vulkan games no longer need the old WoW64 option; existing wrappers are migrated away from stale `PROTON_USE_WOW64` exports.' \
-  '- **Safer live reconfiguration and stall recovery:** Transient partial configuration writes are retried. Frame Generation and Adaptive Target, Maximum Multiplier, and Smooth Cadence can update in place when resources permit; resource-shape and model settings are deferred, so restart the game to guarantee those changes. A transient backend stall keeps native presentation active and warms temporal history before generation resumes.' \
-  '- **Private layer discovery migration:** The `.25` wrapper regenerates older launchers and retains the uniquely named MAKO Renderer layer on the proven SDR path. Heroic Flatpak launches explicitly retain Gamescope WSI ahead of MAKO Renderer; Flatpak cleanup recognises both historical isolated and additive layouts.' \
-  '- **Diagnostic log presets:** Installs `~/.local/bin/mako-diagnostics` with focused HDR, Adaptive, recovery, performance, lifecycle, startup, layer, and error filters.' \
-  '- **Monorepo engine packaging:** Maintainers can build a Decky ZIP directly from the sibling MAKO Renderer checkout. The generated ZIP records the exact commit, dirty state, filenames, and checksums without changing the tracked public release pin.' \
-  '- **Documentation:** Expands HDR, dual-architecture, diagnostics, Flatpak migration, local packaging, and community-coverage guidance.' \
+  "$release_changes" \
   '' \
-  '## 🎮 In-game considerations' \
+  'The list above is generated from every non-merge commit that changed MAKO Decky or the shared README after the previous Decky tag.' \
   '' \
-  '> [!TIP]' \
-  '> **Try the game’s V-Sync setting both on and off.** It can make frame delivery feel steadier, but may also add input lag or clash with the game’s FPS cap, VRR, or compositor. Every game is different: compare both options and keep the one that feels smoother and more responsive.' \
+  '## Before you play' \
   '' \
-  'Every game, renderer, and display setup behaves differently. Compare Fixed and Adaptive Frame Generation one setting at a time. For most games, fullscreen is the best starting point for performance and frame pacing. Keep the configuration that feels best for that game.' \
+  '- This is experimental: test each game before relying on it.' \
+  '- Confirm the detected `Lossless.dll` path before launching. Leaving it blank permits normal discovery.' \
+  '- Try the game’s V-Sync both on and off; its FPS cap, VRR, and compositor can affect frame pacing.' \
   '' \
-  'See the [Configuration guide](https://github.com/eugeniosegala/MAKO/blob/main/plugin/docs/CONFIGURATION.md) and [Troubleshooting guide](https://github.com/eugeniosegala/MAKO/blob/main/plugin/docs/TROUBLESHOOTING.md) for the full behaviour and per-game controls.' \
+  "## Bundled MAKO Renderer \`$engine_version\`" \
   '' \
-  '> ⚠️ **Required renderer-update step:** Installing the ZIP updates MAKO Decky, but does **not** by itself replace MAKO Renderer. Open Mako and select **Install MAKO Renderer (developer build)** to install the version bundled in the new ZIP.' \
+  "- Includes checksum-verified \`$archive_name\`." \
+  '- Installing the ZIP does not replace the private Renderer by itself. Open Mako and select **Install MAKO Renderer (developer build)** afterwards.' \
   '' \
   '> [!IMPORTANT]' \
   '> **Preferred clean update:** To prevent Decky retaining a previous plugin backend or bundled payload, especially when moving between local test ZIPs, uninstall **Mako** from Decky, install the newer ZIP, restart your Steam Deck or Steam Machine, then select **Install MAKO Renderer (developer build)** in the plugin.' \
@@ -265,24 +247,16 @@ printf '%s\n' \
   '3. In Game Mode, open Decky Loader’s settings, choose **Developer** > **Install Plugin from Zip**, then select the newer ZIP.' \
   '4. Restart your Steam Deck or Steam Machine.' \
   '5. ⚠️ **Required:** Open Mako and select **Install MAKO Renderer (developer build)** to install the version bundled in the new ZIP.' \
-  '6. If you use Heroic, select **Flatpak Setup**, then select **Update** for Heroic’s matching runtime extension (usually **25.08**). This replaces its Flatpak layer with the engine bundled in the new ZIP; Heroic preparation and per-game Wrapper commands remain unchanged.' \
+  '6. In **Flatpak Setup**, select **Update** for every prepared application’s matching runtime extension. This replaces its Flatpak layer with the engine bundled in the new ZIP while preserving its preparation and per-game Wrapper commands.' \
   '' \
   'Experimental profiles and Steam launch options are retained. The private native renderer and launcher are re-created in step 5; shared Flatpak extensions are retained, then refreshed in step 6.' \
   '' \
-  "## Known limitations of MAKO Renderer $engine_version" \
+  '## Known limitations' \
   '' \
   '- **HDR is in progress and unavailable in this Decky release:** The engine foundation is included, but the plugin locks HDR exposure off and does not provide a per-game opt-in. In-game HDR controls may be unavailable by design. A later release can unlock the path after activation, presentation, colour, and performance are validated across games.' \
   '- **Adaptive targets are not hard frame limiters:** Adaptive varies generated-frame count toward an average target. It cannot reduce a native framerate already above the target, exceed the configured multiplier/GPU/compositor capacity, or guarantee an unreachable output rate.' \
   '- **Image-quality and latency trade-offs remain game-dependent:** Higher multipliers and lower real-frame rates can increase ghosting and input latency. Smooth Cadence may improve motion consistency while reducing responsiveness.' \
   '' \
-  '## Before you play' \
-  '' \
-  '- This is experimental: test each game before relying on it.' \
-  '- Confirm the detected `Lossless.dll` path before launching. Leaving it blank permits upstream discovery.' \
-  '' \
-  '## Engine payload' \
-  '' \
-  "- Bundles checksum-verified \`$archive_name\`." \
   >> "$notes_file"
 
 echo "Publishing $plugin_release_tag to $github_repository..."


### PR DESCRIPTION
## Summary

- Refresh MAKO, engine, and plugin setup, configuration, and troubleshooting documentation.
- Clarify SteamOS support, migration guidance, clean updates, and download paths.
- Generate release notes from component tags in the publishing scripts.

## Why

These commits align the documentation and release workflow with the current MAKO renderer and Decky plugin experience.

## Validation

- git diff --check origin/main..HEAD
- pnpm test — 51 tests passed