### PR TITLE
render: degrade to native presentation when render fence budget is missed

### DIFF
--- a/engine/mako-render/src/swapchain.cpp
+++ b/engine/mako-render/src/swapchain.cpp
@@ -1855,6 +1855,14 @@ VkResult Swapchain::present(const vk::Vulkan& vk,
         if (!backendReady)
             return presentNativeFrame();
 
+        // A previous fence-budget miss leaves the render fence in flight.
+        // Poll it without adding another 150 ms wait to every native present;
+        // recovery can proceed only after the fence is actually complete.
+        if (this->renderFenceInFlight && !this->renderFence->wait(vk, 0))
+            return presentNativeFrame();
+        if (this->renderFenceInFlight)
+            this->renderFenceInFlight = false;
+
         this->backendRecoveryPending = false;
         this->generatedImageAdmission.reset();
         this->pipelineBusyRecovery.reset();
@@ -2019,22 +2027,50 @@ VkResult Swapchain::present(const vk::Vulkan& vk,
         }
     }
 
-    const auto prepareRenderFence = [&]() {
+    const auto prepareRenderFence = [&]() -> bool {
         if (renderFencePrepared)
-            return;
+            return true;
         if (this->renderFenceInFlight) {
             const bool fenceSignaled = this->renderFence->wait(
                 vk, 150ULL * 1000 * 1000
             );
             if (!fenceSignaled) {
-                throw ls::error(
-                    "timed out waiting for the previous render fence"
-                );
+                // A missed fence budget is queue congestion, not a fatal
+                // backend failure: during long application stalls (asset
+                // streaming, shader compilation) the previous generated
+                // submission can legitimately sit behind game work far
+                // beyond the 150 ms budget. Bypass generation for this
+                // present, retain native presentation, and recover through
+                // the regular backend recovery path instead of surfacing
+                // VK_ERROR_UNKNOWN to the application.
+                std::cerr << "mako: previous render work missed the 150 ms "
+                             "fence budget; bypassing frame generation for "
+                             "this present; native presentation retained\n";
+                if (this->adaptiveScheduler) {
+                    this->adaptiveScheduler->reportGeneratedFrameDelivery(
+                        generatedFrameCount, 0
+                    );
+                    this->adaptiveScheduler->cancelHistoryWarmup();
+                } else {
+                    this->fixedDiagnosticSkippedFrames +=
+                        generatedFrameCount;
+                }
+                this->backendRecoveryPending = true;
+                this->configurationHistoryWarmupRemaining = 0;
+                if (presentDiagnosticsEnabled()) {
+                    std::cerr << "mako: present diagnostics: "
+                                 "operation=render-fence-budget-missed"
+                              << " context=" << this->diagnosticsContextId
+                              << " planned=" << generatedFrameCount
+                              << " action=native-present\n";
+                }
+                return false;
             }
             this->renderFenceInFlight = false;
         }
         this->renderFence->reset(vk);
         renderFencePrepared = true;
+        return true;
     };
 
     // HDR bridge admission is nonblocking. Reserve every generated destination
@@ -2123,6 +2159,11 @@ VkResult Swapchain::present(const vk::Vulkan& vk,
         scheduledTimestamps.data(), scheduledGeneratedFrameCount
     };
 
+    // wait for completion of previous frame before new work is scheduled,
+    // so a missed fence budget cannot strand already-scheduled backend work
+    if (!prepareRenderFence())
+        return presentNativeFrame();
+
     // schedule frame generation
     if (!bypassGeneratedFrames) {
         const auto scheduleStarted = startPresentDiagnostic();
@@ -2158,9 +2199,6 @@ VkResult Swapchain::present(const vk::Vulkan& vk,
         this->backendFrameIndex++;
         logSlowPresentOperation("schedule-frames", this->fidx, this->idx, scheduleStarted);
     }
-
-    // wait for completion of previous frame
-    prepareRenderFence();
 
     // copy swapchain image into backend source image
     const auto& cmdbuf = *this->renderCommandBuffer;


### PR DESCRIPTION
# PR Title

render: degrade to native presentation when the render fence budget is missed

## Summary

On the Ordered SDR (fifo-ordered) path, `prepareRenderFence()` waited 150 ms
for the previous frame-generation submission and threw on timeout. The
exception reached `myvkQueuePresentKHR()`, which returned `VK_ERROR_UNKNOWN`
to the application, freezing games whose render loops treat unexpected
present results as fatal. Reproduced with Farming Simulator 25: the game
locks up on the savegame loading screen whenever a loading stall pushes the
fence past the budget.

This PR makes a missed fence budget non-fatal, following the same degradation
pattern already used by the `scheduleFrames()` failure handler:

- `prepareRenderFence()` now returns `bool`. On timeout it reports the
  generated-frame delivery miss, cancels history warmup, sets
  `backendRecoveryPending`, and returns `false`.
- `present()` returns `presentNativeFrame()` when the fence budget is missed,
  so the game's own image is handed to the driver with only the game's
  semaphores — no fences, no generated work.
- While recovery is pending, an in-flight render fence is polled with a
  zero-timeout check before backend recovery is cleared. Native presents stay
  nonblocking until the old submission completes; the next frame then performs
  the normal reset and history warmup.
- The fence wait was moved **before** the `scheduleFrames()` call. Previously
  a timeout occurring after scheduling would have stranded backend work that
  waits on a timeline value the bypassed source-copy submit never signals;
  checking first guarantees nothing is scheduled that the bypass path cannot
  feed.

Behavior is unchanged for the HDR transport: the pipeline-ready fast path
already clears `renderFenceInFlight` with a zero-timeout poll before
reaching `prepareRenderFence()`, so the new timeout branch remains
SDR-specific in practice.

## Log after the fix

```
mako: previous render work missed the 150 ms fence budget; bypassing frame generation for this present; native presentation retained
```

plus a diagnostics line (`operation=render-fence-budget-missed`) when
`MAKO_PRESENT_DIAGNOSTICS` is enabled.

## Testing

- Farming Simulator 25, savegame load (previously froze within seconds of the
  loading screen with adaptive frame generation): loading completes and frame
  generation resumes through backend recovery once the GPU backlog drains.
- Regular gameplay on the Ordered SDR path: no change in generated-frame
  delivery (the 150 ms budget itself is untouched; only the failure handling
  changed).

Fixes #13
